### PR TITLE
mom5: print the generated config file to stdout.

### DIFF
--- a/packages/mom5/package.py
+++ b/packages/mom5/package.py
@@ -296,8 +296,10 @@ TMPFILES = .*.m *.T *.TT *.hpm *.i *.lst *.proc *.s
 	hpm -r -o $*.hpm $*.x
 """
 
+        fullconfig = config[self.compiler.name] + config["post"]
+        print(fullconfig)
         with open(makeinc_path, "w") as makeinc:
-            makeinc.write(config[self.compiler.name] + config["post"])
+            makeinc.write(fullconfig)
 
     def build(self, spec, prefix):
 


### PR DESCRIPTION
The cice5 SPD already does this. This code was in the same `development` commit as mom5's `netcdf-c~mpi` dependency testing code and did not reach `main`