### PR TITLE
nci-openmpi: use env.append_flags()

### DIFF
--- a/packages/nci-openmpi/package.py
+++ b/packages/nci-openmpi/package.py
@@ -34,8 +34,10 @@ class NciOpenmpi(Package):
         elif self.spec.satisfies("%gcc"):
             finc_path = join_path(self.prefix.include, "GNU")
             flib_path = join_path(self.prefix.lib, "GNU")
-        env.append_path("OMPI_FCFLAGS", "-I" + finc_path)
-        env.append_path("OMPI_LDFLAGS", "-L" + self.prefix.lib + " -L" + flib_path)
+
+        env.append_flags("OMPI_FCFLAGS", "-I" + finc_path)
+        env.append_flags("OMPI_LDFLAGS", "-L" + self.prefix.lib)
+        env.append_flags("OMPI_LDFLAGS", "-L" + flib_path)
 
     # The following is reproduced from the builtin openmpi spack package
     def setup_dependent_build_environment(self, env, dependent_spec):


### PR DESCRIPTION
* Use env.append_flags() instead of env.append_path().
* Thanks to Aidan Heerdegen for finding env.append_flags().