### PR TITLE
nci-openmpi: do not rely on implicit import of spack.package

### DIFF
--- a/packages/nci-openmpi/package.py
+++ b/packages/nci-openmpi/package.py
@@ -1,7 +1,8 @@
-## Adapted from https://github.com/spack/spack/blob/v0.20.0/var/spack/repos/builtin/packages/openmpi/package.py
-## Scott Wales 2023
+# Adapted from https://github.com/spack/spack/blob/v0.20.0/var/spack/repos/builtin/packages/openmpi/package.py
+# Scott Wales 2023
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.package import *
 
 class NciOpenmpi(Package):
     """
@@ -14,6 +15,8 @@ class NciOpenmpi(Package):
           externals:
             - spec: nci-openmpi@4.1.4
               prefix: /apps/openmpi/4.1.4
+              modules:
+              - openmpi/4.1.4
           buildable: False
     """
 


### PR DESCRIPTION
* Spack is planning on removing the implicit import of spack.package. See https://github.com/spack/spack/pull/39380
* Recommended changes from the code review have been add. See https://github.com/ACCESS-NRI/spack-packages/pull/21