### PR TITLE
Add gcom4 package

### DIFF
--- a/packages/gcom4/package.py
+++ b/packages/gcom4/package.py
@@ -21,7 +21,7 @@ class Gcom4(Package):
     homepage = "https://code.metoffice.gov.uk/trac/gcom"
     git = "git@github.com:ACCESS-NRI/GCOM.git"
 
-    maintainers = ["penguian"]
+    maintainers("penguian")
 
     version("4.5", branch="dev")
     build_directory = join_path("Share", "gcom4.5_access_config")

--- a/packages/gcom4/package.py
+++ b/packages/gcom4/package.py
@@ -83,11 +83,9 @@ class Gcom4(Package):
 
     def install(self, spec, prefix):
         """
-        Install the library.
+        Build and install the library.
         """
-        fcm = which("fcm")
-        if fcm is None:
-            raise FileNotFoundError("fcm not found in $PATH")
+        self.build(spec, prefix)
         with fs.working_dir(self.build_directory):
             mkdirp(prefix.lib)
             install(

--- a/packages/gcom4/package.py
+++ b/packages/gcom4/package.py
@@ -36,14 +36,16 @@ class Gcom4(Package):
         Perform the equivalent of the following sed commands:
         sed -i '/build.target{ns}/d' $@/fcm-make/gcom.cfg
         sed -i 's/-openmp/-qopenmp/g' $@/fcm-make/machines/nci_ifort_openmpi.cfg
+        sed -i 's/-openmp/-qopenmp/g' $@/fcm-make/machines/nci_ifort_serial.cfg
         """
         with fs.working_dir(self.build_directory):
             filter_file(
                 r"build\.target\{ns\}.*", "#",
                 join_path("fcm-make", "gcom.cfg"))
-            filter_file(
-                r"-openmp", "-qopenmp",
-                join_path("fcm-make", "machines", "nci_ifort_openmpi.cfg"))
+            for mach_m in ["openmpi", "serial"]:
+                filter_file(
+                    r"-openmp", "-qopenmp",
+                        join_path("fcm-make", "machines", f"nci_ifort_{mach_m}.cfg"))
 
             
     def build(self, spec, prefix):

--- a/packages/gcom4/package.py
+++ b/packages/gcom4/package.py
@@ -1,0 +1,89 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# Copyright 2024 ACCESS-NRI
+# Based on gcom/package.py by scottwales 2023
+# and https://github.com/coecms/access-esm-build-gadi/blob/master/Makefile
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+import llnl.util.filesystem as fs
+import llnl.util.tty as tty
+
+
+class Gcom4(Package):
+    """
+    GCOM is a wrapper around multiprocessing libraries such as MPI
+    Gcom4 is a package for older versions of GCOM as used by UM vn7.3 in ACCESS ESM 1.5
+    """
+
+    homepage = "https://code.metoffice.gov.uk/trac/gcom"
+    git = "git@github.com:ACCESS-NRI/GCOM.git"
+
+    maintainers = ["penguian"]
+
+    version("4.5", branch="dev")
+    build_directory = join_path("Share", "gcom4.5_access_config")
+
+    variant("mpi", default=True, description="Build with MPI")
+
+    depends_on("fcm", type="build")
+    depends_on("mpi", when="+mpi")
+
+
+    def patch(self):
+        """
+        Perform the equivalent of the following sed commands:
+        sed -i '/build.target{ns}/d' $@/fcm-make/gcom.cfg
+        sed -i 's/-openmp/-qopenmp/g' $@/fcm-make/machines/nci_ifort_openmpi.cfg
+        """
+        with fs.working_dir(self.build_directory):
+            filter_file(
+                r"build\.target\{ns\}.*", "#",
+                join_path("fcm-make", "gcom.cfg"))
+            filter_file(
+                r"-openmp", "-qopenmp",
+                join_path("fcm-make", "machines", "nci_ifort_openmpi.cfg"))
+
+            
+    def install(self, spec, prefix):
+
+        fcm = which("fcm")
+        if fcm is None:
+            raise FileNotFoundError("fcm not found in $PATH")
+        with fs.working_dir(self.build_directory):
+    
+            # Set up variables used by fcm-make/gcom.cfg
+            env["ACTION"] = "preprocess build"
+            env["DATE"] = ""
+            env["GCOM_SOURCE"] = "$HERE/.."
+            env["MIRROR"] = ""
+            env["REMOTE_ACTION"] = ""
+            env["ROSE_TASK_MIRROR_TARGET"] = "localhost"
+    
+            # Decide on the build variant
+            if spec.satisfies("%intel"):
+                mach_c = "ifort"
+            elif spec.satisfies("%gcc"):
+                mach_c = "gfortran"
+            else:
+                raise NotImplementedError("Unknown compiler")
+            if "+mpi" in spec:
+                mach_m = "openmpi"
+            else:
+                mach_m = "serial"
+    
+            env["GCOM_MACHINE"] = f"nci_{mach_c}_{mach_m}"
+    
+            # Do the build with fcm
+            fcm("make", "-f", join_path("fcm-make", "gcom.cfg"))
+    
+            # Install the library
+            mkdirp(prefix.lib)
+            install(
+                join_path("build", "lib", "libgcom.a"),
+                join_path(prefix.lib, "libgcom.a"))
+            install_tree(join_path("build", "include"), prefix.include)
+

--- a/packages/gcom4/package.py
+++ b/packages/gcom4/package.py
@@ -10,7 +10,6 @@
 from spack.package import *
 
 import llnl.util.filesystem as fs
-import llnl.util.tty as tty
 
 
 class Gcom4(Package):

--- a/packages/gcom4/package.py
+++ b/packages/gcom4/package.py
@@ -27,7 +27,6 @@ class Gcom4(Package):
     build_directory = join_path("Share", "gcom4.5_access_config")
 
     variant("mpi", default=True, description="Build with MPI")
-
     depends_on("fcm", type="build")
     depends_on("mpi", when="+mpi")
 
@@ -47,8 +46,10 @@ class Gcom4(Package):
                 join_path("fcm-make", "machines", "nci_ifort_openmpi.cfg"))
 
             
-    def install(self, spec, prefix):
-
+    def build(self, spec, prefix):
+        """
+        Build the library.
+        """
         fcm = which("fcm")
         if fcm is None:
             raise FileNotFoundError("fcm not found in $PATH")
@@ -78,8 +79,16 @@ class Gcom4(Package):
     
             # Do the build with fcm
             fcm("make", "-f", join_path("fcm-make", "gcom.cfg"))
-    
-            # Install the library
+
+
+    def install(self, spec, prefix):
+        """
+        Install the library.
+        """
+        fcm = which("fcm")
+        if fcm is None:
+            raise FileNotFoundError("fcm not found in $PATH")
+        with fs.working_dir(self.build_directory):
             mkdirp(prefix.lib)
             install(
                 join_path("build", "lib", "libgcom.a"),


### PR DESCRIPTION
Closes Issue #68 . See that issue for a description of the change requested.

This package applies patches to files in https://github.com/ACCESS-NRI/GCOM/tree/dev/Share/gcom4.5_access_config
as per https://github.com/coecms/access-esm-build-gadi/blob/master/Makefile rather than relying on updating the upstream repository.

The package has been tested to the point where the install completes.