### PR TITLE
Fix mpi logic in CABLE SPD

### DIFF
--- a/packages/cable/package.py
+++ b/packages/cable/package.py
@@ -41,6 +41,5 @@ class Cable(CMakePackage):
 
     def cmake_args(self):
         args = []
-        if self.spec.satisfies("+mpi"):
-            args.append(self.define_from_variant("CABLE_MPI", "mpi"))
+        args.append(self.define_from_variant("CABLE_MPI", "mpi"))
         return args


### PR DESCRIPTION
Currently the CABLE spack build leaves the `CABLE_MPI` CMake variable unset when `~mpi` is satisfied and relies on the default value for `CABLE_MPI`. This change removes the if condition around `define_from_variant` so that `CABLE_MPI` is specified to CMake regardless of how the mpi variant is set.

Fixes #76