### PR TITLE
Add restart_repro variant to access-om2 (default true)

### DIFF
--- a/packages/access-om2/package.py
+++ b/packages/access-om2/package.py
@@ -19,6 +19,7 @@ class AccessOm2(BundlePackage):
     version("latest")
 
     variant("deterministic", default=False, description="Deterministic build.")
+    variant("restart_repro", default=True, description="Reproducible across varying restart boundaries")
 
     depends_on("libaccessom2+deterministic", when="+deterministic")
     depends_on("libaccessom2~deterministic", when="~deterministic")
@@ -26,5 +27,7 @@ class AccessOm2(BundlePackage):
     depends_on("cice5~deterministic", when="~deterministic")
     depends_on("mom5+deterministic", when="+deterministic")
     depends_on("mom5~deterministic", when="~deterministic")
+    depends_on("mom5+restart_repro", when="+restart_repro")
+    depends_on("mom5~restart_repro", when="~restart_repro")
 
     # There is no need for install() since there is no code.

--- a/packages/access-om2/package.py
+++ b/packages/access-om2/package.py
@@ -25,9 +25,11 @@ class AccessOm2(BundlePackage):
     depends_on("libaccessom2~deterministic", when="~deterministic")
     depends_on("cice5+deterministic", when="+deterministic")
     depends_on("cice5~deterministic", when="~deterministic")
-    depends_on("mom5+deterministic", when="+deterministic")
-    depends_on("mom5~deterministic", when="~deterministic")
-    depends_on("mom5+restart_repro", when="+restart_repro")
-    depends_on("mom5~restart_repro", when="~restart_repro")
+    with when("+deterministic"):
+        depends_on("mom5+deterministic+restart_repro", when="+restart_repro")
+        depends_on("mom5+deterministic~restart_repro", when="~restart_repro")
+    with when("~deterministic"):
+        depends_on("mom5~deterministic+restart_repro", when="+restart_repro")
+        depends_on("mom5~deterministic~restart_repro", when="~restart_repro")
 
     # There is no need for install() since there is no code.


### PR DESCRIPTION
Add +restart_repro variant to access-om2 (default true)

As the variant only needs to be propagated to `mom5` it doesn't add a heap of ugly combinatorial boilerplate.

Closes #78 