### PR TITLE
Add `ACCESS-OM2-BGC` Package

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,6 +1,5 @@
 select = ["E","F"]
-ignore = ["E221","E241","E272","E731", "F403","F405","F821"]
-line-length = 88
+ignore = ["E221","E241","E272","E501","E731", "F403","F405","F821"]
 output-format = "github"
 
 # "E129", "F999" aren't supported

--- a/packages/access-om2-bgc/package.py
+++ b/packages/access-om2-bgc/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# Copyright 2023 ACCESS-NRI
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+class AccessOm2Bgc(BundlePackage):
+    """ACCESS-OM2 bundle contains the coupled CICE5 and MOM5 (BGC variant) models."""
+
+    homepage = "https://www.access-nri.org.au"
+
+    git = "https://github.com/ACCESS-NRI/ACCESS-OM2-BGC.git"
+
+    maintainers = ["harshula"]
+
+    version("latest")
+
+    variant("deterministic", default=False, description="Deterministic build.")
+
+    depends_on("libaccessom2+deterministic", when="+deterministic")
+    depends_on("libaccessom2~deterministic", when="~deterministic")
+    depends_on("cice5+deterministic", when="+deterministic")
+    depends_on("cice5~deterministic", when="~deterministic")
+    depends_on("mom5+deterministic type=ACCESS-OM-BGC", when="+deterministic")
+    depends_on("mom5~deterministic type=ACCESS-OM-BGC", when="~deterministic")
+
+    # There is no need for install() since there is no code.

--- a/packages/access-om2-bgc/package.py
+++ b/packages/access-om2-bgc/package.py
@@ -8,7 +8,7 @@
 from spack.package import *
 
 class AccessOm2Bgc(BundlePackage):
-    """ACCESS-OM2 bundle contains the coupled CICE5 and MOM5 (BGC variant) models."""
+    """ACCESS-OM2-BGC bundle contains the coupled CICE5 and MOM5 (BGC variant) models."""
 
     homepage = "https://www.access-nri.org.au"
 


### PR DESCRIPTION
In this PR:
﻿
* Added access-om2-bgc package definition, inheriting from AccessOm2 package
* .ruff.toml: Removed check on line length as part of #73

Closes #80
Closes #73
