### PR TITLE
Initial package for dummygrib

### DIFF
--- a/packages/dummygrib/package.py
+++ b/packages/dummygrib/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# Copyright 2024 ACCESS-NRI
+# Based on https://github.com/coecms/access-esm-build-gadi/blob/master/Makefile
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Dummygrib(MakefilePackage):
+    """
+    dummygrib is a Dummy GRIB library to use with the Met Office Unified Model.
+    """
+
+    homepage = "https://github.com/coecms/dummygrib"
+    git = "git@github.com:coecms/dummygrib.git"
+
+    maintainers("penguian")
+
+    version("1.0", branch="master")
+
+
+    def install(self, spec, prefix):
+
+        # Install the library
+        mkdirp(prefix.lib)
+        install(
+            "libdummygrib.a",
+            join_path(prefix.lib, "libdummygrib.a"))
+

--- a/packages/dummygrib/package.py
+++ b/packages/dummygrib/package.py
@@ -15,7 +15,7 @@ class Dummygrib(MakefilePackage):
     """
 
     homepage = "https://github.com/coecms/dummygrib"
-    git = "git@github.com:coecms/dummygrib.git"
+    git = "https://github.com/coecms/dummygrib.git"
 
     maintainers("penguian")
 


### PR DESCRIPTION
The repository at https://github.com/coecms/dummygrib includes a `Makfile` without an `install` target. The package for `dummygrib` is based on `MakefilePackage` with an added `install` member function. Tested the package, and the library builds and installs with both `gcc-8.5.0` and `intel-19.0.5.281` compilers.
