### PR TITLE
Changed `depends_on` call to actual package name

### DIFF
--- a/packages/access-om3/package.py
+++ b/packages/access-om3/package.py
@@ -25,4 +25,4 @@ class AccessOm3(BundlePackage):
 
     version("latest")
 
-    depends_on("access-om3-cmake")
+    depends_on("access-om3-nuopc")


### PR DESCRIPTION
In this PR:
* access-om3: Added correct depends_on argument - was the old `access-om3-cmake`. Whoops. 