### PR TITLE
Added `submodule` attribute to `access-om3-nuopc`

### DIFF
--- a/packages/access-om3-nuopc/package.py
+++ b/packages/access-om3-nuopc/package.py
@@ -11,7 +11,7 @@ class AccessOm3Nuopc(CMakePackage):
 
     homepage = "https://www.github.com/COSIMA/access-om3"
     git = "https://github.com/COSIMA/access-om3.git"
-
+    submodules = True
     maintainers = ["micaeljtoliveira", "aekiss"]
 
     version("main", branch="main", submodules=True)


### PR DESCRIPTION
@aidanheerdegen had found that there are packages in the `spack.builtins` that use a top-level `submodules = True` attribute that forces cloning of submodules for all versions, not just the ones that are in `version(..., submodules = True)`. This isn't found in the documentation, but it has been quite difficult trawling through the documentation, anyway. 

This is especially helpful for checking out versions properly in the `@git.` syntax, which aren't necessarily going to all be enumerated by `version(...)` methods. 

A similar way to do this in `spack.yaml` would be to add it to the `spack.packages.*.package_attributes` field, like so:

```yaml
spack:
  packages:
    access-om3-nuopc:
      # ...
      package_attributes:
        submodules: True
```
See more in https://spack.readthedocs.io/en/latest/packages_yaml.html#assigning-package-attributes

In this PR:
* `access-om3-nuopc`: Added submodule checkout for all versions