### PR TITLE
Add support for the Intel ifx compiler

### DIFF
--- a/packages/cice4/package.py
+++ b/packages/cice4/package.py
@@ -97,6 +97,9 @@ endif
 LDFLAGS    := $(FFLAGS) -v -static-intel 
 """
 
+        # Add support for the ifx compiler
+        config["oneapi"] = config["intel"]
+
         # Based on https://github.com/ACCESS-NRI/cice4/blob/access-esm1.5/bld/Macros.nci
         config["post"] = """
 MOD_SUFFIX := mod

--- a/packages/cice5/package.py
+++ b/packages/cice5/package.py
@@ -150,6 +150,9 @@ else
 endif
 """
 
+        # Add support for the ifx compiler
+        config["oneapi"] = config["intel"]
+
         # Copied from bld/Macros.nci
         config["post"] = """
 MOD_SUFFIX := mod

--- a/packages/mom5/package.py
+++ b/packages/mom5/package.py
@@ -216,6 +216,9 @@ endif
 LDFLAGS += $(LIBS)
 """
 
+        # Add support for the ifx compiler
+        config["oneapi"] = config["intel"]
+
         # Copied from bin/mkmf.template.t90
         config["post"] = """
 # you should never need to change any lines below.

--- a/packages/oasis3-mct/package.py
+++ b/packages/oasis3-mct/package.py
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import install, join_path, mkdirp
-from pprint import pprint
+# from pprint import pprint
 
 # https://spack.readthedocs.io/en/latest/build_systems/makefilepackage.html
 class Oasis3Mct(MakefilePackage):
@@ -282,6 +282,9 @@ else
     MCT_FCFLAGS     = $(NCI_REPRO_FLAGS) $(NCI_OPTIM_FLAGS) -ip
 endif
 """
+
+        # Add support for the ifx compiler
+        config["oneapi"] = config["intel"]
 
         config["post"] = f"""
 f90FLAGS_1  = $(F90FLAGS_1)


### PR DESCRIPTION
[Updated 06/05/2024]

This PR is the first step to addressing Issue https://github.com/ACCESS-NRI/spack-packages/issues/52
Fixes: `==> Error: KeyError: 'oneapi'`