### PR TITLE
Move variants/compiler flags from `spack.yaml` to relevant `package.py`s

### DIFF
--- a/packages/access-om3-nuopc/package.py
+++ b/packages/access-om3-nuopc/package.py
@@ -57,7 +57,7 @@ class AccessOm3Nuopc(CMakePackage):
     depends_on("netcdf-fortran@4.6.0:")
     depends_on("esmf@8.3.0: +debug")
     depends_on("fms@2021.03: build_type==RelWithDebInfo")
-    depends_on("parallelio@2.5.10: build_type==RelWithDebInfo")
+    depends_on("parallelio@2.5.10: build_type==RelWithDebInfo fflags='-qno-opt-dynamic-align -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model source' cflags='-qno-opt-dynamic-align -fp-model precise -std=gnu99'")
     depends_on("fortranxml@4.1.2:")
 
     flag_handler = CMakePackage.build_system_flags

--- a/packages/access-om3-nuopc/package.py
+++ b/packages/access-om3-nuopc/package.py
@@ -58,15 +58,14 @@ class AccessOm3Nuopc(CMakePackage):
     depends_on("netcdf-fortran@4.6.0:")
     depends_on("esmf@8.3.0:")
     depends_on("fortranxml@4.1.2:")
+    depends_on("fms@2021.03: build_type==RelWithDebInfo precision=64 +large_file ~gfs_phys ~quad_precision ~openmp", when="~openmp")
+    depends_on("fms@2021.03: build_type==RelWithDebInfo precision=64 +large_file ~gfs_phys ~quad_precision +openmp", when="+openmp")
 
     for compiler in supported_compilers():
         if compiler == 'intel':
-            depends_on("fms@2021.03: build_type==RelWithDebInfo precision=64 +large_file ~gfs_phys ~quad_precision ~openmp", when="~openmp")
-            depends_on("fms@2021.03: build_type==RelWithDebInfo precision=64 +large_file ~gfs_phys ~quad_precision +openmp", when="+openmp")
             depends_on("parallelio@2.5.10: build_type==RelWithDebInfo fflags='-qno-opt-dynamic-align -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model source' cflags='-qno-opt-dynamic-align -fp-model precise -std=gnu99'")
         else:
-            depends_on("fms@2021.03:")
-            depends_on("parallelio@2.5.10:")
+            depends_on("parallelio@2.5.10: build_type==RelWithDebInfo")
 
     flag_handler = CMakePackage.build_system_flags
 

--- a/packages/access-om3-nuopc/package.py
+++ b/packages/access-om3-nuopc/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import CMakePackage, variant, version, depends_on
+from spack.compilers import supported_compilers
 
 
 class AccessOm3Nuopc(CMakePackage):
@@ -55,10 +56,17 @@ class AccessOm3Nuopc(CMakePackage):
     depends_on("cmake@3.18:", type="build")
     depends_on("mpi")
     depends_on("netcdf-fortran@4.6.0:")
-    depends_on("esmf@8.3.0: +debug")
-    depends_on("fms@2021.03: build_type==RelWithDebInfo precision=64 +large_file ~gfs_phys ~openmp ~quad_precision")
-    depends_on("parallelio@2.5.10: build_type==RelWithDebInfo fflags='-qno-opt-dynamic-align -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model source' cflags='-qno-opt-dynamic-align -fp-model precise -std=gnu99'")
+    depends_on("esmf@8.3.0:")
     depends_on("fortranxml@4.1.2:")
+
+    for compiler in supported_compilers():
+        if compiler == 'intel':
+            depends_on("fms@2021.03: build_type==RelWithDebInfo precision=64 +large_file ~gfs_phys ~quad_precision ~openmp", when="~openmp")
+            depends_on("fms@2021.03: build_type==RelWithDebInfo precision=64 +large_file ~gfs_phys ~quad_precision +openmp", when="+openmp")
+            depends_on("parallelio@2.5.10: build_type==RelWithDebInfo fflags='-qno-opt-dynamic-align -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model source' cflags='-qno-opt-dynamic-align -fp-model precise -std=gnu99'")
+        else:
+            depends_on("fms@2021.03:")
+            depends_on("parallelio@2.5.10:")
 
     flag_handler = CMakePackage.build_system_flags
 

--- a/packages/access-om3-nuopc/package.py
+++ b/packages/access-om3-nuopc/package.py
@@ -55,7 +55,7 @@ class AccessOm3Nuopc(CMakePackage):
     depends_on("cmake@3.18:", type="build")
     depends_on("mpi")
     depends_on("netcdf-fortran@4.6.0:")
-    depends_on("esmf@8.3.0:")
+    depends_on("esmf@8.3.0: +debug")
     depends_on("fms@2021.03: build_type==RelWithDebInfo")
     depends_on("parallelio@2.5.10: build_type==RelWithDebInfo")
     depends_on("fortranxml@4.1.2:")

--- a/packages/access-om3-nuopc/package.py
+++ b/packages/access-om3-nuopc/package.py
@@ -58,14 +58,13 @@ class AccessOm3Nuopc(CMakePackage):
     depends_on("netcdf-fortran@4.6.0:")
     depends_on("esmf@8.3.0:")
     depends_on("fortranxml@4.1.2:")
-    depends_on("fms@2021.03: build_type==RelWithDebInfo precision=64 +large_file ~gfs_phys ~quad_precision)
+    depends_on("fms@2021.03: build_type==RelWithDebInfo precision=64 +large_file ~gfs_phys ~quad_precision")
     depends_on("fms +openmp", when="+openmp")
     depends_on("fms ~openmp", when="~openmp")
 
     depends_on("parallelio@2.5.10: build_type==RelWithDebInfo")
-    for compiler in supported_compilers():
-        if compiler == 'intel':
-            depends_on("parallelio fflags='-qno-opt-dynamic-align -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model source' cflags='-qno-opt-dynamic-align -fp-model precise -std=gnu99'")
+    if 'intel' in supported_compilers():
+        depends_on("parallelio fflags='-qno-opt-dynamic-align -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model source' cflags='-qno-opt-dynamic-align -fp-model precise -std=gnu99'")
 
     flag_handler = CMakePackage.build_system_flags
 

--- a/packages/access-om3-nuopc/package.py
+++ b/packages/access-om3-nuopc/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.package import CMakePackage, variant, version
+from spack.package import CMakePackage, variant, version, depends_on
 
 
 class AccessOm3Nuopc(CMakePackage):
@@ -56,8 +56,8 @@ class AccessOm3Nuopc(CMakePackage):
     depends_on("mpi")
     depends_on("netcdf-fortran@4.6.0:")
     depends_on("esmf@8.3.0:")
-    depends_on("fms@2021.03:")
-    depends_on("parallelio@2.5.10:")
+    depends_on("fms@2021.03: build_type==RelWithDebInfo")
+    depends_on("parallelio@2.5.10: build_type==RelWithDebInfo")
     depends_on("fortranxml@4.1.2:")
 
     flag_handler = CMakePackage.build_system_flags

--- a/packages/access-om3-nuopc/package.py
+++ b/packages/access-om3-nuopc/package.py
@@ -56,7 +56,7 @@ class AccessOm3Nuopc(CMakePackage):
     depends_on("mpi")
     depends_on("netcdf-fortran@4.6.0:")
     depends_on("esmf@8.3.0: +debug")
-    depends_on("fms@2021.03: build_type==RelWithDebInfo")
+    depends_on("fms@2021.03: build_type==RelWithDebInfo precision=64 +large_file ~gfs_phys ~openmp ~quad_precision")
     depends_on("parallelio@2.5.10: build_type==RelWithDebInfo fflags='-qno-opt-dynamic-align -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model source' cflags='-qno-opt-dynamic-align -fp-model precise -std=gnu99'")
     depends_on("fortranxml@4.1.2:")
 

--- a/packages/access-om3-nuopc/package.py
+++ b/packages/access-om3-nuopc/package.py
@@ -58,14 +58,14 @@ class AccessOm3Nuopc(CMakePackage):
     depends_on("netcdf-fortran@4.6.0:")
     depends_on("esmf@8.3.0:")
     depends_on("fortranxml@4.1.2:")
-    depends_on("fms@2021.03: build_type==RelWithDebInfo precision=64 +large_file ~gfs_phys ~quad_precision ~openmp", when="~openmp")
-    depends_on("fms@2021.03: build_type==RelWithDebInfo precision=64 +large_file ~gfs_phys ~quad_precision +openmp", when="+openmp")
+    depends_on("fms@2021.03: build_type==RelWithDebInfo precision=64 +large_file ~gfs_phys ~quad_precision)
+    depends_on("fms +openmp", when="+openmp")
+    depends_on("fms ~openmp", when="~openmp")
 
+    depends_on("parallelio@2.5.10: build_type==RelWithDebInfo")
     for compiler in supported_compilers():
         if compiler == 'intel':
-            depends_on("parallelio@2.5.10: build_type==RelWithDebInfo fflags='-qno-opt-dynamic-align -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model source' cflags='-qno-opt-dynamic-align -fp-model precise -std=gnu99'")
-        else:
-            depends_on("parallelio@2.5.10: build_type==RelWithDebInfo")
+            depends_on("parallelio fflags='-qno-opt-dynamic-align -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model source' cflags='-qno-opt-dynamic-align -fp-model precise -std=gnu99'")
 
     flag_handler = CMakePackage.build_system_flags
 


### PR DESCRIPTION
See https://github.com/ACCESS-NRI/ACCESS-OM3/pull/5#issuecomment-2089614861 and `spack.yaml` in https://github.com/ACCESS-NRI/ACCESS-OM3/pull/5/files#diff-e8582e74fa156f4e5729a850e52b24f2fde2d815c2c9c360f88c4cf90db851ab

In this PR:
* Propagate `build_type==RelWithDebInfo` down the relevant dependencies in `access-om3-nuopc`
* Move compiler flags into the `depends_on` functions (if they are `intel` compilers)
* Removed `+deprecated_io` variant
* Removed `+install_libraries`, instead using the default `~install_libraries`

Closes #102 