### PR TITLE
Use conditional values for the `type` variant

### DIFF
--- a/packages/mom5/package.py
+++ b/packages/mom5/package.py
@@ -19,19 +19,24 @@ class Mom5(MakefilePackage):
     version("master", branch="master", preferred=True)
     version("access-esm1.5", branch="access-esm1.5")
 
-    variant("type", default="ACCESS-OM", description="Build MOM5 to support a particular use case.", values=("ACCESS-CM", "ACCESS-ESM", "ACCESS-OM", "ACCESS-OM-BGC", "MOM_solo"), multi=False)
     variant("restart_repro", default=True, description="Reproducible restart build.")
     # The following two variants are not applicable when version is "access-esm1.5":
     variant("deterministic", default=False, description="Deterministic build.")
     variant("optimisation_report", default=False, description="Generate optimisation reports.")
-    with when("@access-esm1.5"):
-        variant("type", default="ACCESS-CM", description="Build MOM5 to support a particular ESM use case.", values=("ACCESS-CM", ), multi=False)
+    variant("type", default="ACCESS-OM",
+        # https://spack.readthedocs.io/en/latest/packaging_guide.html#conditional-possible-values
+        values=(
+            "ACCESS-CM",
+            # Spack does not have a spec syntax for NOT "@access-esm1.5", so use version ranges instead
+            conditional("ACCESS-ESM", "ACCESS-OM", "ACCESS-OM-BGC", "MOM_solo", when="@:access-esm0,access-esm2:")),
+        multi=False,
+        description="Build MOM5 to support a particular use case.")
 
     # Depend on virtual package "mpi".
     depends_on("mpi")
     depends_on("netcdf-fortran@4.5.2:")
     depends_on("netcdf-c@4.7.4:")
-    # Spack does not have a spec syntax for NOT "@access-esm1.5", so use version ranges instead
+
     with when("@:access-esm0,access-esm2:"):
         depends_on("datetime-fortran")
         depends_on("oasis3-mct+deterministic", when="+deterministic")


### PR DESCRIPTION
Closes #112 
I tested with three different variants:
```
$ spack find -v mom5
-- linux-rocky8-x86_64 / intel@19.0.5.281 -----------------------
mom5@access-esm1.5~deterministic~optimisation_report+restart_repro build_system=makefile type=ACCESS-CM  mom5@master~deterministic~optimisation_report+restart_repro build_system=makefile type=ACCESS-OM
mom5@master~deterministic~optimisation_report+restart_repro build_system=makefile type=ACCESS-CM
==> 3 installed packages
```
Everything works for me as I expect. Please test.