### PR TITLE
Add version access-esm1.5 to um7

### DIFF
--- a/packages/um7/package.py
+++ b/packages/um7/package.py
@@ -24,6 +24,7 @@ class Um7(Package):
 
     # https://code.metoffice.gov.uk/trac/um/wiki/PastReleases
     version("7.3")
+    version("access-esm1.5", branch="access-esm1.5")
 
     maintainers("penguian")
 

--- a/packages/um7/package.py
+++ b/packages/um7/package.py
@@ -23,7 +23,7 @@ class Um7(Package):
     git = "git@github.com:ACCESS-NRI/UM_v7.git"
 
     # https://code.metoffice.gov.uk/trac/um/wiki/PastReleases
-    version("7.3")
+    version("7.3", branch="main", preferred=True)
     version("access-esm1.5", branch="access-esm1.5")
 
     maintainers("penguian")


### PR DESCRIPTION
Closes #117.

Tested by successfully running
```
spack install um7@access-esm1.5^openmpi@4.0.2%intel@19.0.5.281 arch=linux-rocky8-x86_64
```
