### PR TITLE
access-esm1p5: pass type to depends_on()

### DIFF
--- a/packages/access-esm1p5/package.py
+++ b/packages/access-esm1p5/package.py
@@ -29,9 +29,9 @@ class AccessEsm1p5(BundlePackage):
 
     version("latest")
 
-    depends_on("cice4@access-esm1.5")
-    depends_on("mom5@access-esm1.5")
+    depends_on("cice4@access-esm1.5", type="run")
+    depends_on("mom5@access-esm1.5", type="run")
     # um7 is in a private repository
-    depends_on("um7@access-esm1.5")
+    depends_on("um7@access-esm1.5", type="run")
 
     # There is no need for install() since there is no code.


### PR DESCRIPTION
* Passing type="run" to help with module autoloading as per: https://spack.readthedocs.io/en/v0.22.0/module_file_support.html#autoloading-and-hiding-dependencies