### PR TITLE
access-om2-bgc: pass type to depends_on()

### DIFF
--- a/packages/access-om2-bgc/package.py
+++ b/packages/access-om2-bgc/package.py
@@ -20,11 +20,19 @@ class AccessOm2Bgc(BundlePackage):
 
     variant("deterministic", default=False, description="Deterministic build.")
 
-    depends_on("libaccessom2+deterministic", when="+deterministic")
-    depends_on("libaccessom2~deterministic", when="~deterministic")
-    depends_on("cice5+deterministic", when="+deterministic")
-    depends_on("cice5~deterministic", when="~deterministic")
-    depends_on("mom5+deterministic type=ACCESS-OM-BGC", when="+deterministic")
-    depends_on("mom5~deterministic type=ACCESS-OM-BGC", when="~deterministic")
+    depends_on("libaccessom2+deterministic", when="+deterministic", type="run")
+    depends_on("libaccessom2~deterministic", when="~deterministic", type="run")
+    depends_on("cice5+deterministic", when="+deterministic", type="run")
+    depends_on("cice5~deterministic", when="~deterministic", type="run")
+    depends_on(
+        "mom5+deterministic type=ACCESS-OM-BGC",
+        when="+deterministic",
+        type="run"
+    )
+    depends_on(
+        "mom5~deterministic type=ACCESS-OM-BGC",
+        when="~deterministic",
+        type="run"
+    )
 
     # There is no need for install() since there is no code.


### PR DESCRIPTION
* Passing type="run" to help with module autoloading as per: https://spack.readthedocs.io/en/v0.22.0/module_file_support.html#autoloading-and-hiding-dependencies