### PR TITLE
nci-openmpi: remove explict setup_run_environment() call

### DIFF
--- a/packages/nci-openmpi/package.py
+++ b/packages/nci-openmpi/package.py
@@ -44,7 +44,6 @@ class NciOpenmpi(Package):
 
     # The following is reproduced from the builtin openmpi spack package
     def setup_dependent_build_environment(self, env, dependent_spec):
-        self.setup_run_environment(env)
 
         # Use the spack compiler wrappers under MPI
         env.set("OMPI_CC", spack_cc)


### PR DESCRIPTION
* Fixes #65
* For details, refer to: https://github.com/spack/spack/issues/42700