### PR TITLE
access-om3-nuopc: depend on esmf with -fp-model precise

### DIFF
--- a/packages/access-om3-nuopc/package.py
+++ b/packages/access-om3-nuopc/package.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import CMakePackage, variant, version, depends_on
-from spack.compilers import supported_compilers
-
 
 class AccessOm3Nuopc(CMakePackage):
     """ACCESS-OM3 global ocean-sea ice-wave coupled model."""
@@ -57,16 +55,14 @@ class AccessOm3Nuopc(CMakePackage):
     depends_on("mpi")
     depends_on("netcdf-fortran@4.6.0:")
     depends_on("esmf@8.3.0:")
+    depends_on("esmf cflags='-fp-model precise' fflags='-fp-model precise'", when="%intel")
     depends_on("fortranxml@4.1.2:")
     depends_on("fms@2021.03: build_type==RelWithDebInfo precision=64 +large_file ~gfs_phys ~quad_precision")
     depends_on("fms +openmp", when="+openmp")
     depends_on("fms ~openmp", when="~openmp")
 
     depends_on("parallelio@2.5.10: build_type==RelWithDebInfo")
-
-    if 'intel' in supported_compilers():
-        depends_on("esmf cflags='-fp-model precise' fflags='-fp-model precise'")
-        depends_on("parallelio fflags='-qno-opt-dynamic-align -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model source' cflags='-qno-opt-dynamic-align -fp-model precise -std=gnu99'")
+    depends_on("parallelio fflags='-qno-opt-dynamic-align -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model source' cflags='-qno-opt-dynamic-align -fp-model precise -std=gnu99'", when="%intel")
 
     flag_handler = CMakePackage.build_system_flags
 

--- a/packages/access-om3-nuopc/package.py
+++ b/packages/access-om3-nuopc/package.py
@@ -63,7 +63,9 @@ class AccessOm3Nuopc(CMakePackage):
     depends_on("fms ~openmp", when="~openmp")
 
     depends_on("parallelio@2.5.10: build_type==RelWithDebInfo")
+
     if 'intel' in supported_compilers():
+        depends_on("esmf cflags='-fp-model precise' fflags='-fp-model precise'")
         depends_on("parallelio fflags='-qno-opt-dynamic-align -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model source' cflags='-qno-opt-dynamic-align -fp-model precise -std=gnu99'")
 
     flag_handler = CMakePackage.build_system_flags


### PR DESCRIPTION
* Also, use when="%intel"