### PR TITLE
Add `submodules = True` to MOM5 SPD

### DIFF
--- a/packages/mom5/package.py
+++ b/packages/mom5/package.py
@@ -13,6 +13,7 @@ class Mom5(MakefilePackage):
 
     homepage = "https://www.access-nri.org.au"
     git = "https://github.com/ACCESS-NRI/mom5.git"
+    submodules = True
 
     maintainers("harshula", "penguian")
 


### PR DESCRIPTION
This PR adds `submodules = True` to the MOM5 SPD to facilitate building with the code changes in https://github.com/ACCESS-NRI/MOM5/pull/27

Closes #133 