### PR TITLE
Add `access-ram3` SBD with `UM` SPD

### DIFF
--- a/packages/access-ram3/package.py
+++ b/packages/access-ram3/package.py
@@ -21,7 +21,7 @@ class AccessRam3(BundlePackage):
 
     git = "https://github.com/ACCESS-NRI/ACCESS-RAM3.git"
 
-    maintainers = ["harshula"]
+    maintainers = ["harshula", "penguian"]
 
     version("latest")
 

--- a/packages/access-ram3/package.py
+++ b/packages/access-ram3/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# Copyright 2024 ACCESS-NRI
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import BundlePackage, version, depends_on
+
+
+class AccessRam3(BundlePackage):
+    """
+    ACCESS-RAM3 bundle containing the UM Package.
+
+    This is used to version the entirety of a released deployment, including
+    the package, it's dependencies, and the version of
+    spack-packages/spack-config that it is bundled with
+    """
+
+    homepage = "https://www.access-nri.org.au"
+
+    git = "https://github.com/ACCESS-NRI/ACCESS-RAM3.git"
+
+    maintainers = ["harshula"]
+
+    version("latest")
+
+    depends_on("um")


### PR DESCRIPTION
Create deployment SBD `access-ram3` for the `ACCESS-NRI/ACCESS-RAM3` repository. Depends solely on `um` package. 

In this PR: 
* Add `packages/access-ram3/package.py` with appropriate dependencies. 

References ACCESS-NRI/ACCESS-RAM3#1