### PR TITLE
ACCESS-ESM1.6 SBD

### DIFF
--- a/packages/access-esm1p5/package.py
+++ b/packages/access-esm1p5/package.py
@@ -30,7 +30,7 @@ class AccessEsm1p5(BundlePackage):
     version("latest")
 
     depends_on("cice4@access-esm1.5", type="run")
-    depends_on("mom5@access-esm1.5", type="run")
+    depends_on("mom5@access-esm1.5 type=ACCESS-CM", type="run")
     # um7 is in a private repository
     depends_on("um7@access-esm1.5", type="run")
 

--- a/packages/access-esm1p6/package.py
+++ b/packages/access-esm1p6/package.py
@@ -1,0 +1,37 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# Copyright 2024 ACCESS-NRI
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+class AccessEsm1p6(BundlePackage):
+    """ACCESS-ESM1.6 bundle contains the coupled UM7, CICE4 and MOM5 models.
+
+    ACCESS-ESM1.6 comprises of:
+
+    * The UKMO UM atmospheric model (v7.3), in the same configuration as
+      ACCESS1.4, at N96 (1.875×1.25 degree), 38 level resolution
+    * The CABLE land surface model with biogeochemistry (CASA-CNP) (CABLE2.4)
+    * The GFDL MOM5 ocean model at 1 degree resolution
+    * The WOMBATlite ocean BGC model (generic tracer version)
+    * The LANL CICE4.1 sea ice model (version as ACCESS1.4)
+    * The OASIS-MCT coupler
+    """
+
+    homepage = "https://www.access-nri.org.au"
+
+    git = "https://github.com/ACCESS-NRI/ACCESS-ESM1.6.git"
+
+    maintainers("dougiesquire")
+
+    version("latest")
+
+    depends_on("cice4@access-esm1.5", type="run")
+    depends_on("mom5@access-esm1.6 type=ACCESS-ESM", type="run")
+    # um7 is in a private repository
+    depends_on("um7@access-esm1.5", type="run")
+
+    # There is no need for install() since there is no code.

--- a/packages/mom5/package.py
+++ b/packages/mom5/package.py
@@ -40,7 +40,7 @@ class Mom5(MakefilePackage):
         depends_on("oasis3-mct~deterministic", when="~deterministic")
         depends_on("libaccessom2+deterministic", when="+deterministic")
         depends_on("libaccessom2~deterministic", when="~deterministic")
-    with when("@access-esm1:access-esm1.6"):
+    with when("@access-esm1.5:access-esm1.6"):
         depends_on("netcdf-c@4.7.1:4.7.4")
         depends_on("netcdf-fortran@4.5.1:4.5.2")
         # Depend on "openmpi".
@@ -61,7 +61,7 @@ class Mom5(MakefilePackage):
         config = {}
 
         # NOTE: The order of the libraries matters during the linking step!
-        if ("@access-esm1.5" in self.spec) or ("@access-esm1.6" in self.spec):
+        if self.spec.satisfies("@access-esm1.5:access-esm1.6"):
             istr = " ".join([
                     join_path((spec["oasis3-mct"].headers).cpp_flags, "psmile.MPI1"),
                     join_path((spec["oasis3-mct"].headers).cpp_flags, "mct")])
@@ -167,7 +167,7 @@ LDFLAGS += $(LIBS)
 """
 
         # Copied from bin/mkmf.template.nci
-        if ("@access-esm1.5" in self.spec) or ("@access-esm1.6" in self.spec):
+        if self.spec.satisfies("@access-esm1.5:access-esm1.6"):
             config["intel"] = f"""
 ifeq ($(VTRACE), yes)
     FC = mpifort-vt
@@ -301,7 +301,7 @@ LDFLAGS += $(LIBS)
         config["oneapi"] = config["intel"]
 
         # Copied from bin/mkmf.template.t90
-        if ("@access-esm1.5" in self.spec) or ("@access-esm1.6" in self.spec):
+        if self.spec.satisfies("@access-esm1.5:access-esm1.6"):
             config["post"] = """
 # you should never need to change any lines below.
 
@@ -487,7 +487,7 @@ TMPFILES = .*.m *.T *.TT *.hpm *.i *.lst *.proc *.s
             build = Executable("./MOM_compile.csh")
             if "+restart_repro" in self.spec:
                 build.add_default_env("REPRO", "true")
-            if "@access-esm1.5" not in self.spec:
+            if self.spec.satisfies("@access-esm1.5"):
                 # The MOM5 commit d7ba13a3f364ce130b6ad0ba813f01832cada7a2
                 # requires the --no_version switch to avoid git hashes being
                 # embedded in the binary.

--- a/packages/mom5/package.py
+++ b/packages/mom5/package.py
@@ -19,6 +19,7 @@ class Mom5(MakefilePackage):
 
     version("master", branch="master", preferred=True)
     version("access-esm1.5", branch="access-esm1.5")
+    version("access-esm1.6", branch="master")
 
     variant("restart_repro", default=True, description="Reproducible restart build.")
     # The following two variants are not applicable when version is "access-esm1.5":
@@ -39,7 +40,7 @@ class Mom5(MakefilePackage):
         depends_on("oasis3-mct~deterministic", when="~deterministic")
         depends_on("libaccessom2+deterministic", when="+deterministic")
         depends_on("libaccessom2~deterministic", when="~deterministic")
-    with when("@access-esm1.5"):
+    with when("@access-esm1:access-esm1.6"):
         depends_on("netcdf-c@4.7.1:4.7.4")
         depends_on("netcdf-fortran@4.5.1:4.5.2")
         # Depend on "openmpi".
@@ -60,7 +61,7 @@ class Mom5(MakefilePackage):
         config = {}
 
         # NOTE: The order of the libraries matters during the linking step!
-        if "@access-esm1.5" in self.spec:
+        if ("@access-esm1.5" in self.spec) or ("@access-esm1.6" in self.spec):
             istr = " ".join([
                     join_path((spec["oasis3-mct"].headers).cpp_flags, "psmile.MPI1"),
                     join_path((spec["oasis3-mct"].headers).cpp_flags, "mct")])
@@ -166,7 +167,7 @@ LDFLAGS += $(LIBS)
 """
 
         # Copied from bin/mkmf.template.nci
-        if "@access-esm1.5" in self.spec:
+        if ("@access-esm1.5" in self.spec) or ("@access-esm1.6" in self.spec):
             config["intel"] = f"""
 ifeq ($(VTRACE), yes)
     FC = mpifort-vt
@@ -300,7 +301,7 @@ LDFLAGS += $(LIBS)
         config["oneapi"] = config["intel"]
 
         # Copied from bin/mkmf.template.t90
-        if "@access-esm1.5" in self.spec:
+        if ("@access-esm1.5" in self.spec) or ("@access-esm1.6" in self.spec):
             config["post"] = """
 # you should never need to change any lines below.
 

--- a/packages/mom5/package.py
+++ b/packages/mom5/package.py
@@ -487,7 +487,7 @@ TMPFILES = .*.m *.T *.TT *.hpm *.i *.lst *.proc *.s
             build = Executable("./MOM_compile.csh")
             if "+restart_repro" in self.spec:
                 build.add_default_env("REPRO", "true")
-            if self.spec.satisfies("@access-esm1.5"):
+            if not self.spec.satisfies("@access-esm1.5"):
                 # The MOM5 commit d7ba13a3f364ce130b6ad0ba813f01832cada7a2
                 # requires the --no_version switch to avoid git hashes being
                 # embedded in the binary.

--- a/packages/mom5/package.py
+++ b/packages/mom5/package.py
@@ -25,11 +25,7 @@ class Mom5(MakefilePackage):
     variant("deterministic", default=False, description="Deterministic build.")
     variant("optimisation_report", default=False, description="Generate optimisation reports.")
     variant("type", default="ACCESS-OM",
-        # https://spack.readthedocs.io/en/latest/packaging_guide.html#conditional-possible-values
-        values=(
-            "ACCESS-CM",
-            # Spack does not have a spec syntax for NOT "@access-esm1.5", so use version ranges instead
-            conditional("ACCESS-ESM", "ACCESS-OM", "ACCESS-OM-BGC", "MOM_solo", when="@:access-esm0,access-esm2:")),
+        values=("ACCESS-CM", "ACCESS-ESM", "ACCESS-OM", "ACCESS-OM-BGC", "MOM_solo"),
         multi=False,
         description="Build MOM5 to support a particular use case.")
 


### PR DESCRIPTION
This PR adds a new SBD for ACCESS-ESM1.6. At the moment, this is only differs from ACCESS-ESM1.5 in how MOM5 is built.

Closes #140 