### PR TITLE
access-test: new SPD to test ACCESS-NRI infrastructure

### DIFF
--- a/packages/access-test/package.py
+++ b/packages/access-test/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# Copyright 2024 ACCESS-NRI
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+class AccessTest(BundlePackage):
+    """ACCESS-TEST bundle is for testing ACCESS-NRI infrastructure."""
+
+    homepage = "https://www.access-nri.org.au"
+
+    git = "https://github.com/ACCESS-NRI/ACCESS-TEST.git"
+
+    maintainers("harshula")
+
+    version("latest")
+
+    variant("deterministic", default=False, description="Deterministic build.")
+
+    depends_on("oasis3-mct+deterministic", when="+deterministic", type="run")
+    depends_on("oasis3-mct~deterministic", when="~deterministic", type="run")
+
+    # There is no need for install() since there is no code.


### PR DESCRIPTION
@atteggiani made a good point that ACCESS-OM2 takes too long to build for testing our Spack instance. That got me thinking whether a Test/QA fake model release would be useful for CI, CD, Spack, Docker and Gadi testing ...

@CodeGat: "I'm starting to think more and more that it'd be a great idea."