### PR TITLE
Add package for fiat based on builtin but adding um as a version

### DIFF
--- a/packages/fiat/intel_warnings_v110.patch
+++ b/packages/fiat/intel_warnings_v110.patch
@@ -1,0 +1,39 @@
+--- a/cmake/fiat_compiler_warnings.cmake
++++ b/cmake/fiat_compiler_warnings.cmake
+@@ -5,12 +5,14 @@ if(HAVE_WARNINGS)
+   ecbuild_add_c_flags("-Wextra"                                NO_FAIL)
+   ecbuild_add_c_flags("-Wno-unused-parameter"                  NO_FAIL)
+   ecbuild_add_c_flags("-Wno-unused-variable"                   NO_FAIL)
+-  ecbuild_add_c_flags("-Wno-gnu-zero-variadic-macro-arguments" NO_FAIL)
++  if (CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
++    ecbuild_add_c_flags("-Wno-gnu-zero-variadic-macro-arguments" NO_FAIL)
++  endif()
+ endif()
+
+ # Always disable some warnings
+ ecbuild_add_c_flags("-Wno-deprecated-declarations" NO_FAIL)
+-if( CMAKE_C_COMPILER_ID MATCHES Intel )
+-  ecbuild_add_c_flags("-diag-disable=279")   # controlling expression is constant
+-  ecbuild_add_c_flags("-diag-disable=11076") # inline limits
+-endif()
++#if( CMAKE_C_COMPILER_ID MATCHES Intel )
++#  ecbuild_add_c_flags("-diag-disable=279")   # controlling expression is constant
++#  ecbuild_add_c_flags("-diag-disable=11076") # inline limits
++#endif()
+--- a/src/fiat/CMakeLists.txt
++++ b/src/fiat/CMakeLists.txt
+@@ -26,10 +26,10 @@ endif()
+
+ ### Compilation flags
+
+-if( CMAKE_Fortran_COMPILER_ID MATCHES "Intel" )
+-  ## To disable checking of argument correctness of dummy mpi symbols
+-  ecbuild_add_fortran_flags( -nowarn nointerfaces )
+-endif()
++#if( CMAKE_Fortran_COMPILER_ID MATCHES "Intel" )
++#  ## To disable checking of argument correctness of dummy mpi symbols
++#  ecbuild_add_fortran_flags( -nowarn nointerfaces )
++#endif()
+
+ if( CMAKE_Fortran_COMPILER_ID MATCHES "GNU" )
+   ecbuild_add_fortran_flags( -ffree-line-length-none )

--- a/packages/fiat/intel_warnings_v120.patch
+++ b/packages/fiat/intel_warnings_v120.patch
@@ -1,0 +1,42 @@
+--- a/cmake/fiat_compiler_warnings.cmake	2023-08-21 08:29:06.000000000 -0600
++++ b/cmake/fiat_compiler_warnings.cmake	2023-08-21 08:37:40.000000000 -0600
+@@ -5,15 +5,17 @@
+   ecbuild_add_c_flags("-Wextra"                                NO_FAIL)
+   ecbuild_add_c_flags("-Wno-unused-parameter"                  NO_FAIL)
+   ecbuild_add_c_flags("-Wno-unused-variable"                   NO_FAIL)
+-  ecbuild_add_c_flags("-Wno-gnu-zero-variadic-macro-arguments" NO_FAIL)
++  if (CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
++    ecbuild_add_c_flags("-Wno-gnu-zero-variadic-macro-arguments" NO_FAIL)
++  endif()
+ endif()
+ 
+ # Always disable some warnings
+ ecbuild_add_c_flags("-Wno-deprecated-declarations" NO_FAIL)
+-if( CMAKE_C_COMPILER_ID MATCHES Intel )
+-  ecbuild_add_c_flags("-diag-disable=279")   # controlling expression is constant
+-  ecbuild_add_c_flags("-diag-disable=11076") # inline limits
+-endif()
++#if( CMAKE_C_COMPILER_ID MATCHES Intel )
++#  ecbuild_add_c_flags("-diag-disable=279")   # controlling expression is constant
++#  ecbuild_add_c_flags("-diag-disable=11076") # inline limits
++#endif()
+ if( CMAKE_Fortran_COMPILER_ID MATCHES Cray )
+   ecbuild_add_fortran_flags("-hnomessage=878") # A module named ... has already been directly or indirectly use associated into this scope
+   ecbuild_add_fortran_flags("-hnomessage=867") # Module ... has no public objects declared in the module, therefore nothing can be use associated from the module.
+--- a/src/fiat/CMakeLists.txt
++++ b/src/fiat/CMakeLists.txt
+@@ -26,10 +26,10 @@ endif()
+
+ ### Compilation flags
+
+-if( CMAKE_Fortran_COMPILER_ID MATCHES "Intel" )
+-  ## To disable checking of argument correctness of dummy mpi symbols
+-  ecbuild_add_fortran_flags( -nowarn nointerfaces )
+-endif()
++#if( CMAKE_Fortran_COMPILER_ID MATCHES "Intel" )
++#  ## To disable checking of argument correctness of dummy mpi symbols
++#  ecbuild_add_fortran_flags( -nowarn nointerfaces )
++#endif()
+
+ if( CMAKE_Fortran_COMPILER_ID MATCHES "GNU" )
+   ecbuild_add_fortran_flags( -ffree-line-length-none )

--- a/packages/fiat/package.py
+++ b/packages/fiat/package.py
@@ -1,0 +1,62 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# Based on spack/var/spack/repos/builtin/packages/fiat/package.py
+
+from spack.package import *
+
+
+class Fiat(CMakePackage):
+    """FIAT (Fortran IFS and Arpege Toolkit) is a collection of selected
+    Fortran utility libraries, extracted from the IFS/Arpege model."""
+
+    homepage = "https://github.com/ecmwf-ifs/fiat"
+    git = "https://github.com/ACCESS-NRI/fiat.git"
+    url = "https://github.com/ecmwf-ifs/fiat/archive/1.0.0.tar.gz"
+
+    maintainers("climbfuji", "penguian")
+
+    license("Apache-2.0")
+
+    version("main", branch="main", no_cache=True)
+    version("um", branch="um", no_cache=True)
+    version("1.2.0", sha256="758147410a4a3c493290b87443b4091660b915fcf29f7c4d565c5168ac67745f")
+    version("1.1.0", sha256="58354e60d29a1b710bfcea9b87a72c0d89c39182cb2c9523ead76a142c695f82")
+    version("1.0.0", sha256="45afe86117142831fdd61771cf59f31131f2b97f52a2bd04ac5eae9b2ab746b8")
+
+    variant(
+        "build_type",
+        default="RelWithDebInfo",
+        description="CMake build type",
+        values=("Debug", "Release", "RelWithDebInfo"),
+    )
+
+    variant("mpi", default=True, description="Use MPI")
+    variant("openmp", default=True, description="Use OpenMP")
+    variant("fckit", default=True, description="Use fckit")
+
+    depends_on("ecbuild", type=("build"))
+    depends_on("mpi", when="+mpi")
+    depends_on("eckit", when="+fckit")
+    depends_on("fckit", when="+fckit")
+
+    patch("intel_warnings_v110.patch", when="@0:1.1.0")
+    patch("intel_warnings_v120.patch", when="@1.2.0:")
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("ENABLE_OMP", "openmp"),
+            self.define_from_variant("ENABLE_MPI", "mpi"),
+            self.define_from_variant("ENABLE_FCKIT", "fckit"),
+        ]
+        if "+mpi" in self.spec:
+            args.extend(
+                [
+                    self.define("CMAKE_C_COMPILER", self.spec["mpi"].mpicc),
+                    self.define("CMAKE_CXX_COMPILER", self.spec["mpi"].mpicxx),
+                    self.define("CMAKE_Fortran_COMPILER", self.spec["mpi"].mpifc),
+                ]
+            )
+        return args


### PR DESCRIPTION
Closes #147 

This package is used by the `um` package to add `DR_HOOK` as per #148.

This package is based on the builtin package, with the following differences.

1. It uses the [ACCESS-NRI/fiat](https://github.com/ACCESS-NRI/fiat.git) repository.
2. It adds a `"um"` version that uses the [`"um"` branch of `ACCESS-NRI/fiat`](https://github.com/ACCESS-NRI/fiat/tree/um). This branch [adds a modified version of `DR_HOOK_DEFAULT` that allows a communicator to be specified](https://github.com/ACCESS-NRI/fiat/commit/77cc81c170a342a7e0056c9a9249708c66587d56).
3. It does not patch the `"um"` version.
4. It adds `"CMAKE_*_COMPILER"` defines to `cmake_args` so that CMake can find the `mpifc` compiler, etc. 

```
$ diff -U0 -w spack/var/spack/repos/builtin/packages/fiat/package.py spack-packages/packages/fiat/package.py 
--- spack/var/spack/repos/builtin/packages/fiat/package.py	2024-09-25 09:25:23.000000000 +1000
+++ spack-packages/packages/fiat/package.py	2024-09-25 10:05:27.000000000 +1000
@@ -5,0 +6,2 @@
+# Based on spack/var/spack/repos/builtin/packages/fiat/package.py
+
@@ -14 +16 @@
-    git = "https://github.com/ecmwf-ifs/fiat.git"
+    git = "https://github.com/ACCESS-NRI/fiat.git"
@@ -17 +19 @@
-    maintainers("climbfuji")
+    maintainers("climbfuji", "penguian")
@@ -21,0 +24 @@
+    version("um", branch="um", no_cache=True)
@@ -42 +45 @@
-    patch("intel_warnings_v110.patch", when="@:1.1.0")
+    patch("intel_warnings_v110.patch", when="@0:1.1.0")
@@ -51 +54,8 @@
-
+        if "+mpi" in self.spec:
+            args.extend(
+                [
+                    self.define("CMAKE_C_COMPILER", self.spec["mpi"].mpicc),
+                    self.define("CMAKE_CXX_COMPILER", self.spec["mpi"].mpicxx),
+                    self.define("CMAKE_Fortran_COMPILER", self.spec["mpi"].mpifc),
+                ]
+            )
```