### PR TITLE
Added specific reference to 'master' version in mom5 and oasis packages

### DIFF
--- a/packages/mom5/package.py
+++ b/packages/mom5/package.py
@@ -30,7 +30,7 @@ class Mom5(MakefilePackage):
         multi=False,
         description="Build MOM5 to support a particular use case.")
 
-    with when("@:access-esm0,access-esm2:"):
+    with when("@master"):
         depends_on("netcdf-c@4.7.4:")
         depends_on("netcdf-fortran@4.5.2:")
         # Depend on virtual package "mpi".

--- a/packages/oasis3-mct/package.py
+++ b/packages/oasis3-mct/package.py
@@ -23,7 +23,7 @@ class Oasis3Mct(MakefilePackage):
     variant("deterministic", default=False, description="Deterministic build.")
     variant("optimisation_report", default=False, description="Generate optimisation reports.")
 
-    with when("@:access-esm0,access-esm2:"):
+    with when("@master"):
         depends_on("netcdf-fortran@4.5.2:")
         # Depend on virtual package "mpi".
         depends_on("mpi")

--- a/packages/oasis3-mct/package.py
+++ b/packages/oasis3-mct/package.py
@@ -251,7 +251,7 @@ f90         = $(F90)
 f           = $(F90)
 """
 
-        config["gcc"] = f"""
+        config["gcc"] = """
 # Compiling and other commands
 MAKE        = make
 F90         = mpif90 -Wall -fallow-argument-mismatch
@@ -295,7 +295,7 @@ endif
         # Add support for the ifx compiler
         config["oneapi"] = config["intel"]
 
-        config["post"] = f"""
+        config["post"] = """
 f90FLAGS_1  = $(F90FLAGS_1)
 FFLAGS_1    = $(F90FLAGS_1)
 fFLAGS_1    = $(F90FLAGS_1)


### PR DESCRIPTION

- [x] Fixes #152.
- [x] Fixed "f-string withoug placeholders" issue with `Ruff` in oassis.