### PR TITLE
Update package.py for GCOM package

### DIFF
--- a/packages/gcom4/package.py
+++ b/packages/gcom4/package.py
@@ -17,7 +17,7 @@ class Gcom4(Package):
     """
 
     homepage = "https://code.metoffice.gov.uk/trac/gcom"
-    git = "git@github.com:ACCESS-NRI/GCOM4.git"
+    git = "https://github.com/ACCESS-NRI/GCOM4.git"
 
     maintainers("penguian")
 


### PR DESCRIPTION
Switch to https for git to avoid need for ssh key password. (Maybe there is a reason for this ?)