### PR TITLE
Revert the recent change to the gcom4 git clone address

### DIFF
--- a/packages/gcom4/package.py
+++ b/packages/gcom4/package.py
@@ -17,7 +17,7 @@ class Gcom4(Package):
     """
 
     homepage = "https://code.metoffice.gov.uk/trac/gcom"
-    git = "https://github.com/ACCESS-NRI/GCOM4.git"
+    git = "git@github.com:ACCESS-NRI/GCOM4.git"
 
     maintainers("penguian")
 


### PR DESCRIPTION
Closes #158 

I tested this change on Gadi as follows:
```
[pcl851@gadi-login-05 ACCESS-NRI]$ spack install gcom4@access-esm1.5%intel@19.0.3.199+mpi target=x86_64_v4
[+] /usr (external glibc-2.28-mqjolvbeskcnhz5chvtdshk4x4sfnycs)
==> openmpi@4.1.5 : has external module in ['openmpi/4.1.5']
[+] /apps/openmpi/4.1.5 (external openmpi-4.1.5-d2fnwga5ru5576ituxh2dnltp2e2qzea)
[+] /g/data/tm70/pcl851/src/ACCESS-NRI/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/fcm-2021.05.0-q2lzrtveje4vtlljpthvpqhszkh3heen
==> Installing gcom4-access-esm1.5-lh6rlw5e6n4z3urwnobg3ncqmtjag3s5 [4/4]
==> No binary for gcom4-access-esm1.5-lh6rlw5e6n4z3urwnobg3ncqmtjag3s5 found: installing from source
==> Ran patch() for gcom4
==> gcom4: Executing phase: 'install'
==> gcom4: Successfully installed gcom4-access-esm1.5-lh6rlw5e6n4z3urwnobg3ncqmtjag3s5
  Stage: 5.54s.  Install: 1m 36.52s.  Post-install: 3.21s.  Total: 1m 45.85s
[+] /g/data/tm70/pcl851/src/ACCESS-NRI/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/gcom4-access-esm1.5-lh6rlw5e6n4z3urwnobg3ncqmtjag3s5
```