### PR TITLE
mom5: use a more accurate name for an environment variable

### DIFF
--- a/packages/mom5/package.py
+++ b/packages/mom5/package.py
@@ -498,7 +498,7 @@ TMPFILES = .*.m *.T *.TT *.hpm *.i *.lst *.proc *.s
                 build.add_default_env("REPRO", "true")
 
             if self.spec.satisfies("+access-gtracers"):
-                build.add_default_env("SPACK_BUILD", "true")
+                build.add_default_env("SPACK_FMS_EXTERNAL", "true")
 
             if not self.spec.satisfies("@access-esm1.5"):
                 # The MOM5 commit d7ba13a3f364ce130b6ad0ba813f01832cada7a2


### PR DESCRIPTION
While debugging an issue, I found that the variable name `$SPACK_BUILD` confusing because we use Spack to build MOM5 regardless of whether that variable is set to true of false.