### PR TITLE
mom5: use environment variable name SPACK_GTRACERS_EXTERNAL

### DIFF
--- a/packages/mom5/package.py
+++ b/packages/mom5/package.py
@@ -498,7 +498,7 @@ TMPFILES = .*.m *.T *.TT *.hpm *.i *.lst *.proc *.s
                 build.add_default_env("REPRO", "true")
 
             if self.spec.satisfies("+access-gtracers"):
-                build.add_default_env("SPACK_FMS_EXTERNAL", "true")
+                build.add_default_env("SPACK_GTRACERS_EXTERNAL", "true")
 
             if not self.spec.satisfies("@access-esm1.5"):
                 # The MOM5 commit d7ba13a3f364ce130b6ad0ba813f01832cada7a2


### PR DESCRIPTION
* The name SPACK_GTRACERS_EXTERNAL is better than SPACK_FMS_EXTERNAL.