### PR TITLE
Spack package to add build options for CICE5 in esm1.6

### DIFF
--- a/packages/cice5/package.py
+++ b/packages/cice5/package.py
@@ -14,9 +14,10 @@ class Cice5(MakefilePackage):
     homepage = "https://www.access-nri.org.au"
     git = "https://github.com/ACCESS-NRI/cice5.git"
 
-    maintainers = ["harshula"]
+    maintainers = ["harshula", "anton-seaice"]
 
     version("master", branch="master", preferred=True)
+    version("access-esm1.6", branch="access-esm1.6")
 
     variant("deterministic", default=False, description="Deterministic build.")
     variant("optimisation_report", default=False, description="Generate optimisation reports.")
@@ -77,8 +78,10 @@ class Cice5(MakefilePackage):
 
         if self.spec.satisfies("@access-esm1.6"):
             # The integer represents environment variable NTASK
-            self.__targets = {12: {}}
+            # esm1.5 used 12 (cice4), cm2 used 16 (cice5), build both for testing
+            self.__targets = {12: {}, 16: {}} 
             self.add_target(12, "access-esm1.6", "360x300", "12x1")
+            self.add_target(16, "access-esm1.6", "360x300", "8x2")
 
             ideps = ["oasis3-mct", "netcdf-fortran"]
 

--- a/packages/cice5/spack-build.sh
+++ b/packages/cice5/spack-build.sh
@@ -53,13 +53,15 @@ if ($driver == 'access-esm1.6') then
   setenv CHAN     MPI1	  # MPI1 or MPI2 (always MPI1!)
   setenv NICELYR  1       # 1 for ktherm=0, zero-layer thermodynamics
   setenv TRBGCS   0
+  # This branch does not include version.F90.template and does not need version_mod.F90
 # else if ($driver == 'access-cm2') then
 #     setenv DRVDIR   'access'
 #     setenv ACCESS   yes
 #     setenv IO_TYPE  netcdf
 #     setenv CHAN     MPI1	  # MPI1 or MPI2 (always MPI1!)
 #     setenv NICELYR  4       #4 for standard multi-layer ice (ktherm=1)
-#     setenv TRBGCS   2 
+#     setenv TRBGCS   2
+      # This branch does not include version.F90.template and does not need version_mod.F90
 else #driver = auscom
   setenv DRVDIR   $driver
   setenv ACCESS   no
@@ -91,7 +93,11 @@ setenv BLCKY `expr $NYGLOB / $NYBLOCK` # y-dimension of blocks (  ghost cells  )
 @ m = $a / $b ; setenv MXBLCKS $m ; if ($MXBLCKS == 0) setenv MXBLCKS 1
 echo Autimatically generated: MXBLCKS = $MXBLCKS
 
-
+###########################################
+# ars599: 24032014
+#	copy from /short/p66/ars599/CICE.v5.0/accice.v504_csiro
+#	solo_ice_comp
+###########################################
 ### Tracers               # match ice_in tracer_nml to conserve memory
 setenv TRAGE   1          # set to 1 for ice age tracer
 setenv TRFY    1          # set to 1 for first-year ice area tracer


### PR DESCRIPTION
@Harshula

When I try to use this package, it builds the wrong executable

I run 

`spack install cice5@git.access-esm1.6=access-esm1.6%intel@19.0.3.199`



and it builds the executable for access-cm2 ?

From the spack-build-out.txt file, I can see that spack is sending the wrong arguments to spack-build.sh :

```
==> cice5: Executing phase: 'build'
==> [2024-11-29-11:34:55.729889] '/g/data/tm70/as2285/spack0.22/spack/var/spack/environments/esm1_5/cice5/bld/spack-build.sh' 'access-cm2' '360x300' '12x1' '12'
```

Any ideas ?