### PR TITLE
access-esm1p6: add variant cice, generic-tracers and um

### DIFF
--- a/packages/access-esm1p6/package.py
+++ b/packages/access-esm1p6/package.py
@@ -8,7 +8,8 @@
 from spack.package import *
 
 class AccessEsm1p6(BundlePackage):
-    """ACCESS-ESM1.6 bundle contains the coupled UM7, CICE4 and MOM5 models.
+    """ACCESS-ESM1.6 bundle contains the coupled UM7, CICE4/CICE5 and MOM5
+       models.
 
     ACCESS-ESM1.6 comprises of:
 
@@ -17,7 +18,7 @@ class AccessEsm1p6(BundlePackage):
     * The CABLE land surface model with biogeochemistry (CASA-CNP) (CABLE2.4)
     * The GFDL MOM5 ocean model at 1 degree resolution
     * The WOMBATlite ocean BGC model (generic tracer version)
-    * The LANL CICE4.1 sea ice model (version as ACCESS1.4)
+    * The LANL CICE4.1 sea ice model (version as ACCESS1.4). CICE5 for testing.
     * The OASIS-MCT coupler
     """
 
@@ -25,13 +26,46 @@ class AccessEsm1p6(BundlePackage):
 
     git = "https://github.com/ACCESS-NRI/ACCESS-ESM1.6.git"
 
-    maintainers("dougiesquire")
+    maintainers("dougiesquire", "harshula")
 
     version("latest")
 
-    depends_on("cice4@access-esm1.5", type="run")
-    depends_on("mom5@access-esm1.6 type=ACCESS-ESM", type="run")
+    variant(
+        "cice",
+        default="4",
+        description="Choose the version of the CICE sea-ice model.",
+        values=("4", "5"),
+        multi=False,
+    )
+    variant(
+        "generic-tracers",
+        default=True,
+        description="Enable generic tracers.",
+    )
+    variant(
+        "um",
+        default="access-esm1.6",
+        description="Choose the branch of um7.",
+        values=("access-esm1.5", "access-esm1.6"),
+        multi=False,
+    )
+
+    depends_on("cice4@access-esm1.5", type="run", when="cice=4")
+    depends_on("cice5@access-esm1.6", type="run", when="cice=5")
+    # TODO: Use the access-esm1.6 branch when it has been confirmed that
+    #       MOM5 master supports building with generic tracers disabled.
+    depends_on(
+        "mom5@access-esm1.5 type=ACCESS-CM",
+        type="run",
+        when="~generic-tracers",
+    )
+    depends_on(
+        "mom5@access-esm1.6 type=ACCESS-ESM",
+        type="run",
+        when="+generic-tracers",
+    )
     # um7 is in a private repository
-    depends_on("um7@access-esm1.5", type="run")
+    depends_on("um7@access-esm1.5", type="run", when="um=access-esm1.5")
+    depends_on("um7@access-esm1.6", type="run", when="um=access-esm1.6")
 
     # There is no need for install() since there is no code.


### PR DESCRIPTION
This PR increases flexibility by allowing the user to make the following choices:
1) cice = {4,5} (only cice4 has been tested)
2) generic-tracers = {True,False} (tested)
3) um = {access-esm1.5,access-esm1.6} (tested)

Closes #175