### PR TITLE
access-om2 SPRs: change the name of the default version

### DIFF
--- a/packages/access-om2/package.py
+++ b/packages/access-om2/package.py
@@ -16,7 +16,7 @@ class AccessOm2(BundlePackage):
 
     maintainers("harshula")
 
-    version("latest")
+    version("access-om2")
 
     variant("deterministic", default=False, description="Deterministic build.")
 

--- a/packages/cice5/package.py
+++ b/packages/cice5/package.py
@@ -14,9 +14,9 @@ class Cice5(MakefilePackage):
     homepage = "https://www.access-nri.org.au"
     git = "https://github.com/ACCESS-NRI/cice5.git"
 
-    maintainers = ["harshula", "anton-seaice"]
+    maintainers("harshula", "anton-seaice")
 
-    version("master", branch="master", preferred=True)
+    version("access-om2", branch="master", preferred=True)
     version("access-esm1.6", branch="access-esm1.6")
 
     variant("deterministic", default=False, description="Deterministic build.")

--- a/packages/libaccessom2/package.py
+++ b/packages/libaccessom2/package.py
@@ -13,9 +13,9 @@ class Libaccessom2(CMakePackage):
     homepage = "https://www.access-nri.org.au"
     git = "https://github.com/ACCESS-NRI/libaccessom2.git"
 
-    maintainers = ["harshula"]
+    maintainers("harshula")
 
-    version("master", branch="master")
+    version("access-om2", branch="master", preferred=True)
 
     variant("deterministic", default=False, description="Deterministic build.")
     variant("optimisation_report", default=False, description="Generate optimisation reports.")

--- a/packages/mom5/package.py
+++ b/packages/mom5/package.py
@@ -17,7 +17,7 @@ class Mom5(MakefilePackage):
 
     maintainers("harshula", "penguian")
 
-    version("master", branch="master", preferred=True)
+    version("access-om2", branch="master", preferred=True)
     version("access-esm1.5", branch="access-esm1.5")
     version("access-esm1.6", branch="master")
 

--- a/packages/oasis3-mct/package.py
+++ b/packages/oasis3-mct/package.py
@@ -17,7 +17,7 @@ class Oasis3Mct(MakefilePackage):
 
     maintainers("harshula", "penguian")
 
-    version("master", branch="master", preferred=True)
+    version("access-om2", branch="master", preferred=True)
     version("access-esm1.5", branch="access-esm1.5")
 
     variant("deterministic", default=False, description="Deterministic build.")


### PR DESCRIPTION
* Originally there was only one version in each SPR. It was used to build access-om2. However, now we have more versions like access-esm1.5. By renaming version "master" to "access-om2", it is clear that is the version used to build access-om2.
* Use the new maintainers() function.
