### PR TITLE
enable building of spack issm installation with wrappers

### DIFF
--- a/packages/issm/package.py
+++ b/packages/issm/package.py
@@ -1,8 +1,7 @@
-# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
-# Spack Project Developers. See the top-level COPYRIGHT file for details.
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # Copyright 2023 Angus Gibson
-# Modified by Justin Kin Jun Hew, 2025
+# Justin Kin Jun Hew, 2025
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
@@ -13,50 +12,109 @@ class Issm(AutotoolsPackage):
     """Ice-sheet and Sea-Level System Model"""
 
     homepage = "https://issm.jpl.nasa.gov/"
-    git = "https://github.com/ISSMteam/ISSM.git"
+    git = "https://github.com/ACCESS-NRI/ISSM.git"
 
-    version("develop", branch="main")
-    version("4.24", sha256="0487bd025f37be4a39dfd48b047de6a6423e310dfe5281dbd9a52aa35b26151a")
-    
     maintainers("justinh2002")
 
+    version("upstream", branch="main", git="https://github.com/ISSMteam/ISSM.git")
+    
+    version("main", branch="main", git="https://github.com/ACCESS-NRI/ISSM.git")
+    version("access-development", branch="access-development", git="https://github.com/ACCESS-NRI/ISSM.git", preferred=True)
+
+    variant("wrappers", default=False,
+            description="Enable building with MPI wrappers")
+    #
+    # Build dependencies
+    #
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
-    depends_on("libtool", type="build")
-    depends_on("m4", type="build")
-
+    depends_on("libtool",  type="build")
+    depends_on("m4",       type="build")
     depends_on("mpi")
     depends_on("petsc+metis+mumps+scalapack")
     depends_on("m1qn3")
 
     conflicts("%gcc@14:", msg="ISSM cannot be built with GCC versions above 13")
+    #
+    # Optional libraries
+    #
+    depends_on('access-triangle', when='+wrappers')
+    depends_on("parmetis",  when="+wrappers")
+    depends_on("python@3.9.2:", when="+wrappers", type=("build", "run"))
+    depends_on("py-numpy", when="+wrappers", type=("build", "run"))
 
     def url_for_version(self, version):
-        return "https://github.com/ISSMteam/ISSM/archive/refs/tags/v{0}.tar.gz".format(version)
+        if version == Version("upstream"):
+            return "https://github.com/ISSMteam/ISSM/archive/refs/heads/main.tar.gz"
+        else:
+            return "https://github.com/ACCESS-NRI/ISSM/archive/refs/heads/{0}.tar.gz".format(version)
 
     def autoreconf(self, spec, prefix):
+        # If the repo has an Autotools build system, run autoreconf:
         autoreconf("--install", "--verbose", "--force")
-
+        
     def configure_args(self):
+        """Populate configure arguments, including optional flags to mimic 
+        your manual `./configure` invocation on Gadi."""
         args = [
-          "--with-wrappers=no",
-          "--enable-debugging",
-          "--enable-development",
-          "--enable-shared",
-          "--without-kriging",
+            "--enable-debugging",
+            "--enable-development",
+            "--enable-shared",
+            "--without-kriging",
         ]
+        #
+        # PETSc, MUMPS, METIS, SCALAPACK, etc.
+        # (Spack typically puts these in the compiler/link environment,
+        #  but if the ISSM configure script looks for explicit --with-* 
+        #  flags, we pass them.)
+        #
         args.append("--with-petsc-dir={0}".format(self.spec["petsc"].prefix))
         args.append("--with-metis-dir={0}".format(self.spec["metis"].prefix))
         args.append("--with-mumps-dir={0}".format(self.spec["mumps"].prefix))
         args.append("--with-m1qn3-dir={0}".format(self.spec["m1qn3"].prefix.lib))
-
-        # Even though we set the MPI compilers manually, the build system
-        # wants us to explicitly request an MPI-enabled build by telling
-        # it the MPI include directory.
+        #
+        # MPI: Even if we use Spack's MPI wrappers, the build system may 
+        # want explicit mention of MPI includes and compilers:
+        #
         args.append("--with-mpi-include={0}".format(self.spec["mpi"].prefix.include))
         args.append("CC=" + self.spec["mpi"].mpicc)
         args.append("CXX=" + self.spec["mpi"].mpicxx)
         args.append("FC=" + self.spec["mpi"].mpifc)
         args.append("F77=" + self.spec["mpi"].mpif77)
+        
+        # If you rely on sca/lapack from PETSc, these lines might 
+        # not be strictly necessary. If ISSM's configure script 
+        # checks them individually, add them:
+        args.append("--with-scalapack-dir={0}".format(self.spec["scalapack"].prefix))
+        #
+        # Wrappers
+        #
+        if "+wrappers" in self.spec:
+            args.append("--with-wrappers=yes")        
+            args.append("--with-parmetis-dir={0}".format(self.spec["parmetis"].prefix))
+            args.append("--with-triangle-dir={0}".format(self.spec["access-triangle"].prefix))
+            python_spec = self.spec["python"]
+            python_version = python_spec.version.up_to(2)
+            python_prefix = self.spec["python"].prefix
 
+            args.append("--with-python-version={0}".format(python_version))
+            args.append("--with-python-dir={0}".format(python_prefix))
+
+            numpy_prefix = self.spec['py-numpy'].prefix
+            numpy_include_dir = join_path(numpy_prefix, 'lib', 'python{0}'.format(python_version), 'site-packages', 'numpy')
+            args.append("--with-python-numpy-dir={0}".format(numpy_include_dir))
+        else:
+            args.append("--with-wrappers=no")
+
+        
         return args
+    
+    def install(self, spec, prefix):
+        # Run the normal Autotools install logic
+        make("install", parallel=False)
+
+        # Copy only the examples directory directly into the prefix directory
+        examples_src = join_path(self.stage.source_path, 'examples')
+        examples_dst = join_path(prefix, 'examples')
+        install_tree(examples_src, examples_dst)
+


### PR DESCRIPTION
see #184  

enable building of Spack issm package installation with wrappers - this allows matlab/python dependencies to be installed; so that Spack can be used to compile issm with pre- and post- processing features, either on a local machine or remote cluster.