### PR TITLE
Add fre-nctools package

### DIFF
--- a/packages/fre-nctools/package.py
+++ b/packages/fre-nctools/package.py
@@ -1,0 +1,41 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class FreNctools(AutotoolsPackage):
+    """FRE-NCtools is a collection of tools for creating grids and mosaics
+    commonly used in climate and weather models, the remapping of data among
+    grids, and the creation and manipulation of netCDF files. These tools were
+    largely written by members of the GFDL Modeling Systems Group primarily for
+    use in the Flexible Modeling System (FMS) Runtime Environment (FRE)
+    supporting the work of the Geophysical Fluid Dynamics Laboratory (GFDL)."""
+
+    # FIXME: Add a proper url for your package's homepage here.
+    homepage = "https://github.com/NOAA-GFDL/FRE-NCtools"
+    url = "https://github.com/NOAA-GFDL/FRE-NCtools/archive/2022.02.tar.gz"
+
+    # FIXME: Add a list of GitHub accounts to
+    # notify when the package is updated.
+    # maintainers = ["github_user1", "github_user2"]
+
+    version("2022.02", sha256="bd90c9c3becdb19ff408c0915e61141376e81c12651a5c1b054c75ced9a73ad2")
+
+    variant("mpi", default=False, description="Builds with MPI support")
+    
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+    depends_on("netcdf-c")
+    depends_on("netcdf-fortran")
+
+    def configure_args(self):
+        spec = self.spec
+
+        args = ["--disable-ocean-model-grid-generator"]
+        if "+mpi" in spec:
+            args.append("--with-mpi")
+        return args

--- a/packages/fre-nctools/package.py
+++ b/packages/fre-nctools/package.py
@@ -20,6 +20,8 @@ class FreNctools(AutotoolsPackage):
 
     maintainers("dougiesquire")
 
+    license("LGPL-3.0-only")
+
     # A number of versions are excluded from this spack package due to bugs:
     # - 2024.05.01: see https://github.com/NOAA-GFDL/FRE-NCtools/issues/344
     # - 2024.03: implicit funcion delcaration in mppncscatter.c; fixed in edcdf78

--- a/packages/fre-nctools/package.py
+++ b/packages/fre-nctools/package.py
@@ -16,7 +16,7 @@ class FreNctools(AutotoolsPackage):
     supporting the work of the Geophysical Fluid Dynamics Laboratory (GFDL)."""
 
     homepage = "https://github.com/NOAA-GFDL/FRE-NCtools"
-    url = "https://github.com/NOAA-GFDL/FRE-NCtools/archive/2022.02.tar.gz"
+    git = "https://github.com/NOAA-GFDL/FRE-NCtools.git"
 
     maintainers("dougiesquire")
 
@@ -30,6 +30,7 @@ class FreNctools(AutotoolsPackage):
     # - 2023.01.01: implicit function declaration in make_topog.c; fixed in 6b4d2fb
     # - 2023.01: implicit function declaration in make_topog.c; fixed in 6b4d2fb
 
+    version("main", branch="main")
     version("2024.05", sha256="61cec52aa03e066b64bed794ef9dc3eb28654c3d1b872aef1b69ce99ef7a9c65")
     version("2024.04", sha256="e27346d7ade1b67af163bb7f327a47a288d5e475fe797323bd7cee3a46385de0")
     version("2024.02", sha256="90d52abc1b467d635dd648185b0046efcc6d58a232143b0ccaf9a0bff23d2f5d")
@@ -44,6 +45,9 @@ class FreNctools(AutotoolsPackage):
     depends_on("netcdf-fortran")
     depends_on("mpi", when="+mpi")
     depends_on("nco", when="@2024.05:")
+
+    def url_for_version(self, version):
+        return "https://github.com/NOAA-GFDL/FRE-NCtools/tarball/v{0}".format(version)
 
     def configure_args(self):
         spec = self.spec

--- a/packages/fre-nctools/package.py
+++ b/packages/fre-nctools/package.py
@@ -1,5 +1,6 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
-# Spack Project Developers. See the top-level COPYRIGHT file for details.
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# Copyright 2025 ACCESS-NRI
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
@@ -14,28 +15,43 @@ class FreNctools(AutotoolsPackage):
     use in the Flexible Modeling System (FMS) Runtime Environment (FRE)
     supporting the work of the Geophysical Fluid Dynamics Laboratory (GFDL)."""
 
-    # FIXME: Add a proper url for your package's homepage here.
     homepage = "https://github.com/NOAA-GFDL/FRE-NCtools"
     url = "https://github.com/NOAA-GFDL/FRE-NCtools/archive/2022.02.tar.gz"
 
-    # FIXME: Add a list of GitHub accounts to
-    # notify when the package is updated.
-    # maintainers = ["github_user1", "github_user2"]
+    maintainers("dougiesquire")
 
+    # A number of versions are excluded from this spack package due to bugs:
+    # - 2024.05.01: see https://github.com/NOAA-GFDL/FRE-NCtools/issues/344
+    # - 2024.03: implicit funcion delcaration in mppncscatter.c; fixed in edcdf78
+    # - 2024.01: implicit function declaration in make_topog.c; fixed in 6b4d2fb
+    # - 2023.01.02: implicit function declaration in make_topog.c; fixed in 6b4d2fb
+    # - 2023.01.01: implicit function declaration in make_topog.c; fixed in 6b4d2fb
+    # - 2023.01: implicit function declaration in make_topog.c; fixed in 6b4d2fb
+
+    version("2024.05", sha256="61cec52aa03e066b64bed794ef9dc3eb28654c3d1b872aef1b69ce99ef7a9c65")
+    version("2024.04", sha256="e27346d7ade1b67af163bb7f327a47a288d5e475fe797323bd7cee3a46385de0")
+    version("2024.02", sha256="90d52abc1b467d635dd648185b0046efcc6d58a232143b0ccaf9a0bff23d2f5d")
     version("2022.02", sha256="bd90c9c3becdb19ff408c0915e61141376e81c12651a5c1b054c75ced9a73ad2")
 
     variant("mpi", default=False, description="Builds with MPI support")
-    
+
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("netcdf-c")
     depends_on("netcdf-fortran")
+    depends_on("mpi", when="+mpi")
+    depends_on("nco", when="@2024.05:")
 
     def configure_args(self):
         spec = self.spec
+        args = []
 
-        args = ["--disable-ocean-model-grid-generator"]
+        # ocean_model_grid_generator subproject removed in 2023.01
+        if spec.version <= Version("2022.02"):
+            args.append("--disable-ocean-model-grid-generator")
+
         if "+mpi" in spec:
             args.append("--with-mpi")
+
         return args

--- a/packages/fre-nctools/package.py
+++ b/packages/fre-nctools/package.py
@@ -47,7 +47,7 @@ class FreNctools(AutotoolsPackage):
     depends_on("nco", when="@2024.05:")
 
     def url_for_version(self, version):
-        return "https://github.com/NOAA-GFDL/FRE-NCtools/tarball/v{0}".format(version)
+        return "https://github.com/NOAA-GFDL/FRE-NCtools/tarball/{0}".format(version)
 
     def configure_args(self):
         spec = self.spec

--- a/packages/fre-nctools/package.py
+++ b/packages/fre-nctools/package.py
@@ -47,7 +47,7 @@ class FreNctools(AutotoolsPackage):
     depends_on("nco", when="@2024.05:")
 
     def url_for_version(self, version):
-        return "https://github.com/NOAA-GFDL/FRE-NCtools/tarball/{0}".format(version)
+        return "https://github.com/NOAA-GFDL/FRE-NCtools/archive/{0}.tar.gz".format(version)
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
This PR adds a package for [FRE-NCtools](https://github.com/NOAA-GFDL/FRE-NCtools). The initial implementation is taken and updated from [COSIMA/spack_packages](https://github.com/COSIMA/spack_packages/blob/main/packages/fre-nctools/package.py).

Closes #143 