### PR TITLE
Added the fix to pickup the oneAPI specific config file for gcom4

### DIFF
--- a/packages/gcom4/package.py
+++ b/packages/gcom4/package.py
@@ -34,6 +34,8 @@ class Gcom4(Package):
         """
         if spec.satisfies("%intel"):
             mach_c = "ifort"
+        elif spec.satisfies("%oneapi"):
+            mach_c = "oneapi"
         elif spec.satisfies("%gcc"):
             mach_c = "gfortran"
         else:
@@ -55,6 +57,8 @@ class Gcom4(Package):
         filter_file(
             r"build\.target\{ns\}.*", "#",
             join_path("fcm-make", "gcom.cfg"))
+        # MS: The oneAPI config already uses the `-qopenmp` flag, so a
+        # substitution is not required for oneAPI.
         if self.spec.satisfies("%intel"):
             machine = self.gcom_machine(self.spec)
             filter_file(


### PR DESCRIPTION
The source repo has already been updated with the oneAPI specific config files in a [separate PR](https://github.com/ACCESS-NRI/GCOM4/pull/6)

I tested with `spack -d install gcom4 %oneapi` and the install was successful with the fix (previously such attempts would crash with [this error](https://github.com/ACCESS-NRI/spack-packages/issues/193#issuecomment-2699325500)). 

```sh
<snip>
==> [2025-03-05-11:25:38.654150]        WRITE: gcom4@access-esm1.5%oneapi@2025.0.4+mpi build_system=generic arch=linux-rocky8-x86_64_v4/3zdxxya [/g/data/tm70/ms2335/spack/0.22/release/modules/linux-rocky8-x86_64_v4/gcom4/access-esm1.5-3zdxxya]
==> [2025-03-05-11:25:39.459366]        EXCLUDED_AS_IMPLICIT : glibc@2.28%oneapi@2025.0.4 build_system=autotools arch=linux-rocky8-x86_64_v4/gkllvhl
==> [2025-03-05-11:25:39.463882]        EXCLUDED_AS_IMPLICIT : intel-oneapi-runtime@2025.0.4%oneapi@2025.0.4 build_system=generic arch=linux-rocky8-x86_64_v4/otx2alp
==> [2025-03-05-11:25:39.468219]        EXCLUDED_AS_IMPLICIT : openmpi@5.0.5%oneapi@2025.0.4~atomics~cuda~gpfs~internal-hwloc~internal-libevent~internal-pmix~java~legacylaunchers~lustre~memchecker~openshmem~orterunprefix~romio+rsh~static+vt+wrapper-rpath build_system=autotools fabrics=none romio-filesystem=none schedulers=none arch=linux-rocky8-x86_64_v4/wazyuoh
==> [2025-03-05-11:25:39.475124] Writing manifest file: No manifest from binary
==> [2025-03-05-11:25:39.720804] gcom4: Successfully installed gcom4-access-esm1.5-3zdxxyajgfjh6cj5floafma6kde6nawk
  Stage: 5.56s.  Install: 1m 23.32s.  Post-install: 1.02s.  Total: 1m 30.34s
[+] /g/data/tm70/ms2335/spack/0.22/release/linux-rocky8-x86_64_v4/oneapi-2025.0.4/gcom4-access-esm1.5-3zdxxyajgfjh6cj5floafma6kde6nawk
==> [2025-03-05-11:25:39.813386] Flagging gcom4-access-esm1.5-3zdxxyajgfjh6cj5floafma6kde6nawk as installed
==> [2025-03-05-11:25:39.813507] Downgrading to a read lock on gcom4-access-esm1.5-3zdxxyajgfjh6cj5floafma6kde6nawk with timeout 1.000ns
==> [2025-03-05-11:25:39.813584] gcom4-access-esm1.5-3zdxxyajgfjh6cj5floafma6kde6nawk is now read locked
==> [2025-03-05-11:25:39.813648] Releasing read lock on gcc-runtime-14.1.0-dmmd5lphbqt7scvbujxcotxgmlxvtlvt
==> [2025-03-05-11:25:39.813715] Releasing read lock on intel-oneapi-runtime-2025.0.4-otx2alpzeflc56jg5fimh4dygkmmurd2
==> [2025-03-05-11:25:39.813759] Releasing read lock on fcm-2021.05.0-mzp53yz4qjvor7wl7x57flf2ryy74r3e
==> [2025-03-05-11:25:39.813799] Releasing read lock on gcom4-access-esm1.5-3zdxxyajgfjh6cj5floafma6kde6nawk
```

Fixes #193 