### PR TITLE
mom5: add oneapi 2025 compiler support

### DIFF
--- a/packages/mom5/package.py
+++ b/packages/mom5/package.py
@@ -306,7 +306,10 @@ LDFLAGS += $(LIBS)
 """
 
         # Add support for the ifx compiler
-        config["oneapi"] = config["intel"]
+        # TODO: `.replace() is a temporary workaround for:
+        # icx: error: unsupported argument 'source' to option '-ffp-model='
+        # The `.replace()` apparently doesn't modify the object.
+        config["oneapi"] = config["intel"].replace("CFLAGS_REPRO := -fp-model precise -fp-model source", "CFLAGS_REPRO := -fp-model precise")
 
         if self.spec.satisfies("@access-esm1.5:access-esm1.6"):
             config["post"] = """


### PR DESCRIPTION
### Testing

ifx:
```
[om2] [gadi-login-05 spack-packages]$ spack find mom5
==> In environment om2
==> 1 root specs
[+] access-om2@access-om2

==> Installed packages
-- linux-rocky8-x86_64 / oneapi@2025.0.4 ------------------------
mom5@git.2025.03.001=access-om2
==> 1 installed package
```

ifort:
```
[root@763ade9cfb88 opt]# spack find mom5
-- linux-rocky8-x86_64 / intel@2021.10.0 ------------------------
mom5@git.2025.03.001=access-om2
==> 1 installed package
```