### PR TITLE
ACCESS-ESM1.5 & ACCESS-ESM1.6: remove versions from dependencies

### DIFF
--- a/packages/cice4/package.py
+++ b/packages/cice4/package.py
@@ -20,10 +20,9 @@ class Cice4(MakefilePackage):
 
     version("access-esm1.5", branch="access-esm1.5")
 
-    depends_on("netcdf-fortran@4.5.1:4.5.2")
-    # Depend on "openmpi".
-    depends_on("openmpi@4.0.2:4.1.0")
-    depends_on("oasis3-mct@access-esm1.5")
+    depends_on("netcdf-fortran@4.5.1:")
+    depends_on("openmpi")
+    depends_on("oasis3-mct")
 
     phases = ["edit", "build", "install"]
 

--- a/packages/mom5/package.py
+++ b/packages/mom5/package.py
@@ -45,11 +45,11 @@ class Mom5(MakefilePackage):
         depends_on("libaccessom2+deterministic", when="+deterministic")
         depends_on("libaccessom2~deterministic", when="~deterministic")
     with when("@access-esm1.5:access-esm1.6"):
-        depends_on("netcdf-c@4.7.1:4.7.4")
-        depends_on("netcdf-fortran@4.5.1:4.5.2")
+        depends_on("netcdf-c@4.7.1:")
+        depends_on("netcdf-fortran@4.5.1:")
         # Depend on "openmpi".
-        depends_on("openmpi@4.0.2:4.1.0")
-        depends_on("oasis3-mct@access-esm1.5")
+        depends_on("openmpi")
+        depends_on("oasis3-mct")
 
     phases = ["edit", "build", "install"]
 

--- a/packages/oasis3-mct/package.py
+++ b/packages/oasis3-mct/package.py
@@ -28,10 +28,9 @@ class Oasis3Mct(MakefilePackage):
         # Depend on virtual package "mpi".
         depends_on("mpi")
     with when("@access-esm1.5"):
-        depends_on("hdf5@1.10.5:1.10.11")
-        depends_on("netcdf-fortran@4.5.1:4.5.2")
+        depends_on("netcdf-fortran@4.5.1:")
         # Depend on "openmpi".
-        depends_on("openmpi@4.0.2:4.1.0")
+        depends_on("openmpi")
 
     phases = ["edit", "build", "install"]
 

--- a/packages/um7/package.py
+++ b/packages/um7/package.py
@@ -27,10 +27,10 @@ class Um7(Package):
 
     depends_on("fcm", type="build")
     depends_on("dummygrib", type=("build", "link"))
-    depends_on("gcom4@access-esm1.5+mpi", type=("build", "link"))
-    depends_on("openmpi@4.0.2:4.1.0", type=("build", "run"))
-    depends_on("netcdf-fortran@4.5.2", type=("build", "link"))
-    depends_on("oasis3-mct@access-esm1.5", type=("build", "link"))
+    depends_on("gcom4+mpi", type=("build", "link"))
+    depends_on("openmpi", type=("build", "run"))
+    depends_on("netcdf-fortran@4.5.2:", type=("build", "link"))
+    depends_on("oasis3-mct", type=("build", "link"))
 
     variant("optim", default="high", description="Optimization level",
             values=("high", "debug"), multi=False)


### PR DESCRIPTION
* The versions do not need to be hardcoded in the SPRs because we define the required versions 
  in the `spack.yaml` Spack environment file.
* Removing hdf5 because it is a dependency of netcdf-c, not oasis3-mct.