### PR TITLE
access-om2: change the version back to latest

### DIFF
--- a/packages/access-om2/package.py
+++ b/packages/access-om2/package.py
@@ -16,7 +16,7 @@ class AccessOm2(BundlePackage):
 
     maintainers("harshula")
 
-    version("access-om2")
+    version("latest")
 
     variant("deterministic", default=False, description="Deterministic build.")
 


### PR DESCRIPTION
It's better to be consistent across all the SBRs and use `latest`.