### PR TITLE
fixed sha256 key and added conflicts directive for building with gcc14 or newer

### DIFF
--- a/packages/issm/package.py
+++ b/packages/issm/package.py
@@ -2,6 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # Copyright 2023 Angus Gibson
+# Modified by Justin Kin Jun Hew, 2025
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
@@ -15,7 +16,9 @@ class Issm(AutotoolsPackage):
     git = "https://github.com/ISSMteam/ISSM.git"
 
     version("develop")
-    version("4.24", sha256="0487bd025f37be4a39dfd48b047de6a6423e310dfe5281dbd9a52aa35b26151a")
+    version("4.24", sha256="c71d870e63f0ce3ae938d6a669e80dc2cecef827084db31a4b2cfc3a26a44820")
+    
+    maintainers("justinh2002")
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
@@ -25,6 +28,8 @@ class Issm(AutotoolsPackage):
     depends_on("mpi")
     depends_on("petsc+metis+mumps+scalapack")
     depends_on("m1qn3")
+
+    conflicts("%gcc@14:", msg="ISSM cannot be built with GCC versions above 13")
 
     def url_for_version(self, version):
         return "https://github.com/ISSMteam/ISSM/tarball/v{0}".format(version)

--- a/packages/issm/package.py
+++ b/packages/issm/package.py
@@ -16,7 +16,7 @@ class Issm(AutotoolsPackage):
     git = "https://github.com/ISSMteam/ISSM.git"
 
     version("develop")
-    version("4.24", sha256="c71d870e63f0ce3ae938d6a669e80dc2cecef827084db31a4b2cfc3a26a44820")
+    version("4.24", sha256="0487bd025f37be4a39dfd48b047de6a6423e310dfe5281dbd9a52aa35b26151a")
     
     maintainers("justinh2002")
 
@@ -32,7 +32,7 @@ class Issm(AutotoolsPackage):
     conflicts("%gcc@14:", msg="ISSM cannot be built with GCC versions above 13")
 
     def url_for_version(self, version):
-        return "https://github.com/ISSMteam/ISSM/tarball/v{0}".format(version)
+        return "https://github.com/ISSMteam/ISSM/archive/refs/tags/v{0}.tar.gz".format(version)
 
     def autoreconf(self, spec, prefix):
         autoreconf("--install", "--verbose", "--force")


### PR DESCRIPTION
hash key is incorrect in the original SPR, see #220 , this is fixed now.

And there are known build conflicts associated with compiling iSSM using `gcc14` or newer, see #172 and #167, a simple fix to this is with Spack's `conflict()` directive, see [Conflicts & Requirements](https://spack.readthedocs.io/en/latest/packaging_guide.html#conflicts-and-requirements), stopping it from installing with `gcc` versions ">=14"