### PR TITLE
made develop version take tarball from main branch

### DIFF
--- a/packages/issm/package.py
+++ b/packages/issm/package.py
@@ -14,7 +14,7 @@ class Issm(AutotoolsPackage):
     homepage = "https://issm.jpl.nasa.gov/"
     git = "https://github.com/ISSMteam/ISSM.git"
 
-    version("develop")
+    version("develop", branch="main")
     version("4.24", sha256="0487bd025f37be4a39dfd48b047de6a6423e310dfe5281dbd9a52aa35b26151a")
 
     depends_on("autoconf", type="build")


### PR DESCRIPTION
Addressing #222, develop version takes from main branch so `spack install issm@develop %gcc@13` now works as expected.