### PR TITLE
remove examples directory from ISSM's SPR

### DIFF
--- a/packages/issm/package.py
+++ b/packages/issm/package.py
@@ -113,8 +113,3 @@ class Issm(AutotoolsPackage):
         # Run the normal Autotools install logic
         make("install", parallel=False)
 
-        # Copy only the examples directory directly into the prefix directory
-        examples_src = join_path(self.stage.source_path, 'examples')
-        examples_dst = join_path(prefix, 'examples')
-        install_tree(examples_src, examples_dst)
-

--- a/packages/issm/package.py
+++ b/packages/issm/package.py
@@ -23,6 +23,9 @@ class Issm(AutotoolsPackage):
 
     variant("wrappers", default=False,
             description="Enable building with MPI wrappers")
+    
+    variant("examples", default=False,
+            description="Build examples")
     #
     # Build dependencies
     #
@@ -112,4 +115,10 @@ class Issm(AutotoolsPackage):
     def install(self, spec, prefix):
         # Run the normal Autotools install logic
         make("install", parallel=False)
+        
+        if "+examples" in self.spec:
+            # Copy the examples directory directly into the prefix directory
+            examples_src = join_path(self.stage.source_path, 'examples')
+            examples_dst = join_path(prefix, 'examples')
+            install_tree(examples_src, examples_dst)
 


### PR DESCRIPTION
remove `examples/` from `self.stage.source_path` #228, just keep standard serialised installation and build.