### PR TITLE
access-fms: set variant gfs_phys default to False

### DIFF
--- a/packages/access-fms/package.py
+++ b/packages/access-fms/package.py
@@ -24,7 +24,7 @@ class AccessFms(CMakePackage):
     version("main", branch="main")
     version("mom5", branch="mom5", preferred=True)
 
-    variant("gfs_phys", default=True, description="Use GFS Physics")
+    variant("gfs_phys", default=False, description="Use GFS Physics")
     variant("large_file", default=False, description="Enable compiler definition -Duse_LARGEFILE.")
     variant(
         "internal_file_nml",


### PR DESCRIPTION
This is needed to preserve answers with ACCESS releases using MOM5 internal FMS - see [here](https://github.com/ACCESS-NRI/access-om2-configs/pull/191#issuecomment-2857276987).