### PR TITLE
Update mom5 SPR for new CMake build system

### DIFF
--- a/packages/access-om2-bgc/package.py
+++ b/packages/access-om2-bgc/package.py
@@ -25,12 +25,12 @@ class AccessOm2Bgc(BundlePackage):
     depends_on("cice5+deterministic", when="+deterministic", type="run")
     depends_on("cice5~deterministic", when="~deterministic", type="run")
     depends_on(
-        "mom5@access-om2-bgc-legacy+deterministic",
+        "mom5@legacy-access-om2-bgc+deterministic",
         when="+deterministic",
         type="run"
     )
     depends_on(
-        "mom5@access-om2-bgc-legacy~deterministic",
+        "mom5@legacy-access-om2-bgc~deterministic",
         when="~deterministic",
         type="run"
     )

--- a/packages/access-om2-bgc/package.py
+++ b/packages/access-om2-bgc/package.py
@@ -25,12 +25,12 @@ class AccessOm2Bgc(BundlePackage):
     depends_on("cice5+deterministic", when="+deterministic", type="run")
     depends_on("cice5~deterministic", when="~deterministic", type="run")
     depends_on(
-        "mom5@legacy-access-om2-bgc+deterministic",
+        "mom5@access-om2-bgc-legacy+deterministic",
         when="+deterministic",
         type="run"
     )
     depends_on(
-        "mom5@legacy-access-om2-bgc~deterministic",
+        "mom5@access-om2-bgc-legacy~deterministic",
         when="~deterministic",
         type="run"
     )

--- a/packages/mom5/package.py
+++ b/packages/mom5/package.py
@@ -1,89 +1,65 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
-# Copyright ACCESS-NRI
-#
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.package import install, join_path, mkdirp
+from spack.package import *
 from spack.version.version_types import GitVersion, StandardVersion
 
-# https://spack.readthedocs.io/en/latest/build_systems/makefilepackage.html
-class Mom5(MakefilePackage):
+class Mom5(CMakePackage):
     """MOM is a numerical ocean model based on the hydrostatic primitive equations."""
 
     homepage = "https://www.access-nri.org.au"
     git = "https://github.com/ACCESS-NRI/mom5.git"
-    submodules = True
 
-    maintainers("harshula", "penguian")
+    maintainers("dougiesquire", "harshula")
 
-    version("access-om2", branch="master", preferred=True)
+    # https://github.com/ACCESS-NRI/MOM5#LGPL-3.0-1-ov-file
+    license("LGPL-3.0-only", checked_by="dougiesquire")
+
+    version("mom_solo", branch="master", preferred=True)
+    version("mom_sis", branch="master")
+    version("access-om2", branch="master")
     version("legacy-access-om2-bgc", branch="master")
-    version("access-esm1.5", branch="access-esm1.5")
     version("access-esm1.6", branch="master")
 
-    variant("restart_repro", default=True, description="Reproducible restart build.")
+    variant("build_type", default="RelWithDebInfo",
+        description="CMake build type",
+        values=("Debug", "Release", "RelWithDebInfo")
+    )
+    variant("deterministic", default=False, description="Deterministic build")
 
-    with when("@access-esm1.6,access-om2,legacy-access-om2-bgc"):
-        variant("deterministic",
-                default=False,
-                description="Deterministic build.")
-        variant("optimisation_report",
-                default=False,
-                description="Generate optimisation reports.")
+    depends_on("cmake@3.18:", type="build")
+    depends_on("mpi")
+    depends_on("netcdf-c@4.7.4:")
+    depends_on("netcdf-fortran@4.5.2:")
 
-    with when("@access-om2,legacy-access-om2-bgc"):
-        depends_on("netcdf-c@4.7.4:")
-        depends_on("netcdf-fortran@4.5.2:")
-        # Depend on virtual package "mpi".
-        depends_on("mpi")
+    with when("@access-om2,access-esm1.6,legacy-access-om2-bgc"):
         depends_on("datetime-fortran")
-        depends_on("oasis3-mct+deterministic", when="+deterministic")
-        depends_on("oasis3-mct~deterministic", when="~deterministic")
         depends_on("libaccessom2+deterministic", when="+deterministic")
         depends_on("libaccessom2~deterministic", when="~deterministic")
-
-    # NOTE: Spack will also match "access-om2-legacy-bgc" here, that's why
-    #       it has been renamed to "legacy-access-om2-bgc".
-    with when("@access-om2"):
+        depends_on("oasis3-mct+deterministic", when="+deterministic")
+        depends_on("oasis3-mct~deterministic", when="~deterministic")
         depends_on("access-fms")
         depends_on("access-generic-tracers")
 
-    # access-esm1.5 and access-esm1.6
-    with when("@access-esm1.5:access-esm1.6"):
-        depends_on("netcdf-c@4.7.1:")
-        depends_on("netcdf-fortran@4.5.1:")
-        # Depend on "openmpi".
-        depends_on("openmpi")
+    root_cmakelists_dir = "cmake/"
 
-    with when("@access-esm1.5"):
-        depends_on("oasis3-mct@access-esm1.5")
+    phases = ["setup", "cmake", "build", "install"]
 
-    with when("@access-esm1.6"):
-        depends_on("oasis3-mct@access-esm1.5+deterministic", when="+deterministic")
-        depends_on("oasis3-mct@access-esm1.5~deterministic", when="~deterministic")
-        depends_on("access-fms")
-        depends_on("access-generic-tracers")
-
-    phases = ["setup", "edit", "build", "install"]
-
-    # NOTE: The keys in the __builds variable are required to check whether
+    # NOTE: The keys in the __types variable are required to check whether
     #       a valid version was passed in by the user.
-    __builds = {
-        "access-om2": {"type": "ACCESS-OM", "gtracers": True},
-        "legacy-access-om2-bgc": {"type": "ACCESS-OM-BGC", "gtracers": False},
-        "access-esm1.5": {"type": "ACCESS-CM", "gtracers": False},
-        "access-esm1.6": {"type": "ACCESS-ESM", "gtracers": True}
+    __types = {
+        "mom_solo": "MOM5_SOLO",
+        "mom_sis": "MOM5_SIS",
+        "access-om2": "MOM5_ACCESS_OM",
+        "access-esm1.6": "MOM5_ACCESS_ESM",
+        "legacy-access-om2-bgc": "MOM5_ACCESS_OM_BGC"
     }
     __version = "INVALID"
-    __platform = "spack"
 
     def url_for_version(self, version):
         return "https://github.com/ACCESS-NRI/mom5/tarball/{0}".format(version)
-
-    # NOTE: This functionality will hopefully be implemented in the Spack core
-    #       in the future. Till then, this approach can be used in other SPRs
-    #       where this functionality is required.
+    
     def setup(self, spec, prefix):
 
         if isinstance(self.version, GitVersion):
@@ -94,492 +70,20 @@ class Mom5(MakefilePackage):
             print("ERROR: version=" + self.version.string)
             raise ValueError
 
-        # The rest of the checks are only required if a __builds member
+        # The rest of the checks are only required if a __types member
         # variable exists
-        if self.__version not in self.__builds.keys():
+        if self.__version not in self.__types.keys():
             print("ERROR: The version must be selected from: " +
-                    ", ".join(self.__builds.keys()))
+                    ", ".join(self.__types.keys()))
             raise ValueError
 
         print("INFO: version=" + self.__version +
-                " type=" + self.__builds[self.__version]["type"] +
-                " gtracers=" + str(self.__builds[self.__version]["gtracers"]))
-
-    def edit(self, spec, prefix):
-
-        srcdir = self.stage.source_path
-        makeinc_path = join_path(srcdir, "bin", "mkmf.template.spack")
-        config = {}
-
-        # NOTE: The order of the libraries matters during the linking step!
-        if self.__version in ["access-esm1.5", "access-esm1.6"]:
-            istr = " ".join([
-                    join_path((spec["oasis3-mct"].headers).cpp_flags, "psmile.MPI1"),
-                    join_path((spec["oasis3-mct"].headers).cpp_flags, "mct")])
-            ideps = ["netcdf-fortran"]
-            ldeps = ["oasis3-mct", "netcdf-c", "netcdf-fortran"]
-            FFLAGS_OPT = "-O3 -debug minimal -xCORE-AVX512 -align array64byte"
-            CFLAGS_OPT = "-O2 -debug minimal -no-vec"
-        else:
-            istr = join_path((spec["oasis3-mct"].headers).cpp_flags, "psmile.MPI1")
-            ideps = ["oasis3-mct", "libaccessom2", "netcdf-fortran"]
-            # NOTE: datetime-fortran is a dependency of libaccessom2.
-            ldeps = ["oasis3-mct", "libaccessom2", "netcdf-c", "netcdf-fortran", "datetime-fortran"]
-
-            # TODO: https://github.com/ACCESS-NRI/ACCESS-OM/issues/12
-            FFLAGS_OPT = "-g3 -O2 -xCORE-AVX2 -debug all -check none -traceback"
-            CFLAGS_OPT = "-O2 -debug minimal -xCORE-AVX2"
-            if self.spec.satisfies("+deterministic"):
-                FFLAGS_OPT = "-g0 -O0 -xCORE-AVX2 -debug none -check none"
-                CFLAGS_OPT = "-O0 -debug none -xCORE-AVX2"
-                print("INFO: +deterministic applied")
-
-        if self.__builds[self.__version]["gtracers"]:
-            ideps.extend(["access-fms", "access-generic-tracers"])
-            ldeps.extend(["access-fms", "access-generic-tracers"])
-
-        incs = " ".join([istr] + [(spec[d].headers).cpp_flags for d in ideps])
-        libs = " ".join([(spec[d].libs).ld_flags for d in ldeps])
-
-        # Copied from bin/mkmf.template.ubuntu
-        config["gcc"] = f"""
-FC = mpifort
-CC = gcc
-LD = $(FC)
-#########
-# flags #
-#########
-DEBUG =
-REPRO =
-VERBOSE =
-OPENMP =
-
-MAKEFLAGS += --jobs=$(shell grep '^processor' /proc/cpuinfo | wc -l)
-
-FPPFLAGS := 
-
-FFLAGS := -fcray-pointer -fdefault-real-8 -ffree-line-length-none -fno-range-check -Waliasing -Wampersand -Warray-bounds -Wcharacter-truncation -Wconversion -Wline-truncation -Wintrinsics-std -Wsurprising -Wno-tabs -Wunderflow -Wunused-parameter -Wintrinsic-shadow -Wno-align-commons -fallow-argument-mismatch -fallow-invalid-boz
-FFLAGS += {incs}
-FFLAGS += -DGFORTRAN
-
-#
-FFLAGS_OPT = -O2
-FFLAGS_REPRO = 
-FFLAGS_DEBUG = -O0 -g -W -fbounds-check 
-FFLAGS_OPENMP = -fopenmp
-FFLAGS_VERBOSE = 
-
-CFLAGS := -D__IFC {incs}
-CFLAGS += $(shell nc-config --cflags)
-CFLAGS_OPT = -O2
-CFLAGS_OPENMP = -fopenmp
-CFLAGS_DEBUG = -O0 -g 
-
-# Optional Testing compile flags.  Mutually exclusive from DEBUG, REPRO, and OPT
-# *_TEST will match the production if no new option(s) is(are) to be tested.
-FFLAGS_TEST = -O2
-CFLAGS_TEST = -O2
-
-LDFLAGS :=
-LDFLAGS_OPENMP := -fopenmp
-LDFLAGS_VERBOSE := 
-
-ifneq ($(REPRO),)
-CFLAGS += $(CFLAGS_REPRO)
-FFLAGS += $(FFLAGS_REPRO)
-endif
-ifneq ($(DEBUG),)
-CFLAGS += $(CFLAGS_DEBUG)
-FFLAGS += $(FFLAGS_DEBUG)
-else ifneq ($(TEST),)
-CFLAGS += $(CFLAGS_TEST)
-FFLAGS += $(FFLAGS_TEST)
-else
-CFLAGS += $(CFLAGS_OPT)
-FFLAGS += $(FFLAGS_OPT)
-endif
-
-ifneq ($(OPENMP),)
-CFLAGS += $(CFLAGS_OPENMP)
-FFLAGS += $(FFLAGS_OPENMP)
-LDFLAGS += $(LDFLAGS_OPENMP)
-endif
-
-ifneq ($(VERBOSE),)
-CFLAGS += $(CFLAGS_VERBOSE)
-FFLAGS += $(FFLAGS_VERBOSE)
-LDFLAGS += $(LDFLAGS_VERBOSE)
-endif
-
-ifeq ($(NETCDF),3)
-  # add the use_LARGEFILE cppdef
-  ifneq ($(findstring -Duse_netCDF,$(CPPDEFS)),)
-    CPPDEFS += -Duse_LARGEFILE
-  endif
-endif
-
-LIBS := {libs}
-LDFLAGS += $(LIBS)
-"""
-
-        # Copied from bin/mkmf.template.nci
-        if self.__version in ["access-esm1.5", "access-esm1.6"]:
-            config["intel"] = f"""
-ifeq ($(VTRACE), yes)
-    FC = mpifort-vt
-    LD = mpifort-vt
-else
-    FC = mpifort
-    LD = mpifort
-endif
-
-CC = mpicc
-
-REPRO =
-VERBOSE =
-OPT = on
-
-MAKEFLAGS += --jobs=4
-
-INCLUDE = {incs}
-
-FPPFLAGS := -fpp -Wp,-w $(INCLUDE)
-FFLAGS := -fno-alias -safe-cray-ptr -fpe0 -ftz -assume byterecl -i4 -r8 -traceback -nowarn -check noarg_temp_created -assume buffered_io -convert big_endian
-FFLAGS_OPT = {FFLAGS_OPT}
-FFLAGS_DEBUG = -g -O0 -debug all -check -check noarg_temp_created -check nopointer -warn -warn noerrors -ftrapuv
-FFLAGS_REPRO = -O2 -debug minimal -no-vec -fp-model precise
-FFLAGS_VERBOSE = -v -V -what
-
-CFLAGS := -D__IFC $(INCLUDE)
-CFLAGS_OPT = {CFLAGS_OPT}
-CFLAGS_DEBUG = -O0 -g -ftrapuv -traceback
-
-LDFLAGS :=
-LDFLAGS_VERBOSE := -Wl,-V,--verbose,-cref,-M
-
-ifneq ($(REPRO),)
-CFLAGS += $(CFLAGS_REPRO)
-FFLAGS += $(FFLAGS_REPRO)
-endif
-
-ifneq ($(DEBUG),)
-CFLAGS += $(CFLAGS_DEBUG)
-FFLAGS += $(FFLAGS_DEBUG)
-else
-CFLAGS += $(CFLAGS_OPT)
-FFLAGS += $(FFLAGS_OPT)
-endif
-
-ifneq ($(VERBOSE),)
-CFLAGS += $(CFLAGS_VERBOSE)
-FFLAGS += $(FFLAGS_VERBOSE)
-LDFLAGS += $(LDFLAGS_VERBOSE)
-endif
-
-LIBS := {libs}
-
-LDFLAGS += $(LIBS)
-"""
-        else:
-            config["intel"] = f"""
-ifeq ($(VTRACE), yes)
-    FC := mpifort-vt
-    LD := mpifort-vt
-else
-    FC := mpifort
-    LD := mpifort
-endif
-
-CC := mpicc
-
-VERBOSE :=
-OPT := on
-
-MAKEFLAGS += -j
-
-INCLUDE   := {incs}
-
-FPPFLAGS := -fpp -Wp,-w $(INCLUDE)
-FFLAGS := -fno-alias -safe-cray-ptr -fpe0 -ftz -assume byterecl -i4 -r8 -nowarn -check noarg_temp_created -assume nobuffered_io -convert big_endian -grecord-gcc-switches -align all
-FFLAGS_OPT := {FFLAGS_OPT}
-FFLAGS_REPORT := -qopt-report=5 -qopt-report-annotate
-FFLAGS_DEBUG := -g3 -O0 -debug all -check -check noarg_temp_created -check nopointer -warn -warn noerrors -ftrapuv -traceback
-FFLAGS_REPRO := -fp-model precise -fp-model source -align all
-FFLAGS_VERBOSE := -v -V -what
-
-CFLAGS := -D__IFC $(INCLUDE)
-CFLAGS_OPT := {CFLAGS_OPT}
-CFLAGS_REPORT := -qopt-report=5 -qopt-report-annotate
-CFLAGS_DEBUG := -O0 -g -ftrapuv -traceback
-CFLAGS_REPRO := -fp-model precise -fp-model source
-
-LDFLAGS :=
-LDFLAGS_VERBOSE := -Wl,-V,--verbose,-cref,-M
-
-ifneq ($(REPRO),)
-CFLAGS += $(CFLAGS_REPRO)
-FFLAGS += $(FFLAGS_REPRO)
-endif
-
-ifneq ($(DEBUG),)
-CFLAGS += $(CFLAGS_DEBUG)
-FFLAGS += $(FFLAGS_DEBUG)
-else
-CFLAGS += $(CFLAGS_OPT)
-FFLAGS += $(FFLAGS_OPT)
-endif
-
-ifneq ($(VERBOSE),)
-CFLAGS += $(CFLAGS_VERBOSE)
-FFLAGS += $(FFLAGS_VERBOSE)
-LDFLAGS += $(LDFLAGS_VERBOSE)
-endif
-
-ifneq ($(REPORT),)
-CFLAGS += $(CFLAGS_REPORT)
-FFLAGS += $(FFLAGS_REPORT)
-endif
-
-LIBS := {libs}
-
-ifneq ($(OASIS_ROOT),)
-LIBS += -L$(OASIS_ROOT)/Linux/lib -lpsmile.MPI1 -lmct -lmpeu -lscrip
-endif
-
-ifneq ($(LIBACCESSOM2_ROOT),)
-LIBS += -L$(LIBACCESSOM2_ROOT)/build/lib -laccessom2
-endif
-
-LDFLAGS += $(LIBS)
-"""
-
-        # Add support for the ifx compiler
-        # TODO: `.replace() is a temporary workaround for:
-        # icx: error: unsupported argument 'source' to option '-ffp-model='
-        # The `.replace()` apparently doesn't modify the object.
-        config["oneapi"] = config["intel"].replace("CFLAGS_REPRO := -fp-model precise -fp-model source", "CFLAGS_REPRO := -fp-model precise")
-
-        if self.__version in ["access-esm1.5", "access-esm1.6"]:
-            config["post"] = """
-# you should never need to change any lines below.
-
-# see the MIPSPro F90 manual for more details on some of the file extensions
-# discussed here.
-# this makefile template recognizes fortran sourcefiles with extensions
-# .f, .f90, .F, .F90. Given a sourcefile <file>.<ext>, where <ext> is one of
-# the above, this provides a number of default actions:
-
-# make <file>.opt	create an optimization report
-# make <file>.o		create an object file
-# make <file>.s		create an assembly listing
-# make <file>.x		create an executable file, assuming standalone
-#			source
-# make <file>.i		create a preprocessed file (for .F)
-# make <file>.i90	create a preprocessed file (for .F90)
-
-# The macro TMPFILES is provided to slate files like the above for removal.
-
-RM = rm -f
-SHELL = /bin/csh -f
-TMPFILES = .*.m *.B *.L *.i *.i90 *.l *.s *.mod *.opt
-
-.SUFFIXES: .F .F90 .H .L .T .f .f90 .h .i .i90 .l .o .s .opt .x
-
-.f.L:
-	$(FC) $(FFLAGS) -c -listing $*.f
-.f.opt:
-	$(FC) $(FFLAGS) -c -opt_report_level max -opt_report_phase all -opt_report_file $*.opt $*.f
-.f.l:
-	$(FC) $(FFLAGS) -c $(LIST) $*.f
-.f.T:
-	$(FC) $(FFLAGS) -c -cif $*.f
-.f.o:
-	$(FC) $(FFLAGS) -c $*.f
-.f.s:
-	$(FC) $(FFLAGS) -S $*.f
-.f.x:
-	$(FC) $(FFLAGS) -o $*.x $*.f *.o $(LDFLAGS)
-.f90.L:
-	$(FC) $(FFLAGS) -c -listing $*.f90
-.f90.opt:
-	$(FC) $(FFLAGS) -c -opt_report_level max -opt_report_phase all -opt_report_file $*.opt $*.f90
-.f90.l:
-	$(FC) $(FFLAGS) -c $(LIST) $*.f90
-.f90.T:
-	$(FC) $(FFLAGS) -c -cif $*.f90
-.f90.o:
-	$(FC) $(FFLAGS) -c $*.f90
-.f90.s:
-	$(FC) $(FFLAGS) -c -S $*.f90
-.f90.x:
-	$(FC) $(FFLAGS) -o $*.x $*.f90 *.o $(LDFLAGS)
-.F.L:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -listing $*.F
-.F.opt:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -opt_report_level max -opt_report_phase all -opt_report_file $*.opt $*.F
-.F.l:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c $(LIST) $*.F
-.F.T:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -cif $*.F
-.F.f:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) -EP $*.F > $*.f
-.F.i:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) -P $*.F
-.F.o:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c $*.F
-.F.s:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -S $*.F
-.F.x:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -o $*.x $*.F *.o $(LDFLAGS)
-.F90.L:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -listing $*.F90
-.F90.opt:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -opt_report_level max -opt_report_phase all -opt_report_file $*.opt $*.F90
-.F90.l:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c $(LIST) $*.F90
-.F90.T:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -cif $*.F90
-.F90.f90:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) -EP $*.F90 > $*.f90
-.F90.i90:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) -P $*.F90
-.F90.o:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c $*.F90
-.F90.s:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -S $*.F90
-.F90.x:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -o $*.x $*.F90 *.o $(LDFLAGS)
-"""
-        else:
-            # Copied from bin/mkmf.template.t90
-            # TODO: Why from `mkmf.template.t90`? Copy bin/mkmf.template.nci.
-            config["post"] = """
-# you should never need to change any lines below.
-
-# see the CF90 manual for more details on some of the file extensions
-# discussed here.
-# this makefile template recognizes fortran sourcefiles with extensions
-# .f, .f90, .F, .F90. Given a sourcefile <file>.<ext>, where <ext> is one of
-# the above, this provides a number of default actions:
-
-# make <file>.T		create a CIF file
-# make <file>.lst	create a compiler listing
-# make <file>.o		create an object file
-# make <file>.s		create an assembly listing
-# make <file>.x		create an executable file, assuming standalone
-#			source
-
-# make <file>.i		create a preprocessed file (only for .F and .F90
-#			extensions)
-
-# make <file>.hpm	produce hpm output from <file>.x
-# make <file>.proc	produce procstat output from <file>.x
-
-# The macro TMPFILES is provided to slate files like the above for removal.
-
-RM = rm -f
-SHELL = /bin/csh
-TMPFILES = .*.m *.T *.TT *.hpm *.i *.lst *.proc *.s
-
-.SUFFIXES: .F .F90 .H .T .f .F90 .h .hpm .i .lst .proc .o .s .x
-
-.f.T:
-	$(FC) $(FFLAGS) -c -Ca $*.f
-.f.lst:
-	$(FC) $(FFLAGS) $(LIST) -c $*.f
-.f.o:
-	$(FC) $(FFLAGS) -c     $*.f
-.f.s:
-	$(FC) $(FFLAGS) -eS    $*.f
-.f.x:
-	$(FC) $(FFLAGS) $(LDFLAGS) -o $*.x $*.f
-.f90.T:
-	$(FC) $(FFLAGS) -c -Ca $*.f90
-.f90.lst:
-	$(FC) $(FFLAGS) $(LIST) -c $*.f90
-.f90.o:
-	$(FC) $(FFLAGS) -c     $*.f90
-.f90.s:
-	$(FC) $(FFLAGS) -c -eS $*.f90
-.f90.x:
-	$(FC) $(FFLAGS) $(LDFLAGS) -o $*.x $*.f90
-.F.T:
-	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FFLAGS) -c -Ca $*.F
-.F.i:
-	$(FC) $(CPPDEFS) $(CPPFLAGS) -eP $*.F
-.F.lst:
-	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FFLAGS) $(LIST) -c $*.F
-.F.o:
-	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FFLAGS) -c     $*.F
-.F.s:
-	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FFLAGS) -c -eS $*.F
-.F.x:
-	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FFLAGS) $(LDFLAGS) -o $*.x $*.F
-.F90.T:
-	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FFLAGS) -c -Ca $*.F90
-.F90.i:
-	$(FC) $(CPPDEFS) $(CPPFLAGS) -eP $*.F90
-.F90.lst:
-	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FFLAGS) $(LIST) -c $*.F90
-.F90.o:
-	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FFLAGS) -c     $*.F90
-.F90.s:
-	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FFLAGS) -c -eS $*.F90
-.F90.x:
-	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FFLAGS) $(LDFLAGS) -o $*.x $*.F90
-.x.proc:
-	procstat -R $*.proc $*.x
-.x.hpm:
-	hpm -r -o $*.hpm $*.x
-"""
-
-        fullconfig = config[self.compiler.name] + config["post"]
-        print(fullconfig)
-        with open(makeinc_path, "w") as makeinc:
-            makeinc.write(fullconfig)
-
-    def build(self, spec, prefix):
-
-        # cd ${ACCESS_OM_DIR}/src/mom/exp
-        # export mom_type=ACCESS-OM
-        # ./MOM_compile.csh --type $mom_type --platform spack
-        with working_dir(join_path(self.stage.source_path, "exp")):
-            build = Executable("./MOM_compile.csh")
-
-            if self.spec.satisfies("+restart_repro"):
-                build.add_default_env("REPRO", "true")
-                print("INFO: +restart_repro applied")
-
-            if self.__builds[self.__version]["gtracers"]:
-                build.add_default_env("SPACK_GTRACERS_EXTERNAL", "true")
-
-            if self.__version != "access-esm1.5":
-                # The MOM5 commit d7ba13a3f364ce130b6ad0ba813f01832cada7a2
-                # requires the --no_version switch to avoid git hashes being
-                # embedded in the binary.
-                build.add_default_arg("--no_version")
-                if self.spec.satisfies("+optimisation_report"):
-                    build.add_default_env("REPORT", "true")
-                    print("INFO: +optimisation_report applied")
-
-            build(
-                "--type",
-                self.__builds[self.__version]["type"],
-                "--platform",
-                self.__platform,
-                "--no_environ"
-            )
-
-    def install(self, spec, prefix):
-
-        mkdirp(prefix.bin)
-        install(
-            join_path(
-                "exec",
-                self.__platform,
-                self.__builds[self.__version]["type"],
-                "fms_" + self.__builds[self.__version]["type"] + ".x"
-            ),
-            prefix.bin
+            " type=" + self.__types[self.__version]
         )
-        install(join_path("bin", "mppnccombine." + self.__platform), prefix.bin)
+
+    def cmake_args(self):
+        args = [
+            self.define("MOM5_TYPE", self.__types[self.__version]),
+            self.define_from_variant("MOM5_DETERMINISTIC", "deterministic"),
+        ]
+        return args

--- a/packages/mom5/package.py
+++ b/packages/mom5/package.py
@@ -62,17 +62,15 @@ class Mom5(CMakePackage, MakefilePackage):
         depends_on("mpi")
 
     with when("@access-om2,legacy-access-om2-bgc"):
+        depends_on("datetime-fortran")
         depends_on("oasis3-mct+deterministic", when="+deterministic")
         depends_on("oasis3-mct~deterministic", when="~deterministic")
+        depends_on("libaccessom2+deterministic", when="+deterministic")
+        depends_on("libaccessom2~deterministic", when="~deterministic")
 
     with when("@access-esm1.6"):
         depends_on("oasis3-mct@access-esm1.5+deterministic", when="+deterministic")
         depends_on("oasis3-mct@access-esm1.5~deterministic", when="~deterministic")
-
-    with when("@access-om2,legacy-access-om2-bgc"):
-        depends_on("datetime-fortran")
-        depends_on("libaccessom2+deterministic", when="+deterministic")
-        depends_on("libaccessom2~deterministic", when="~deterministic")
 
     # NOTE: Spack will also match "access-om2-legacy-bgc" here, that's why
     #       it has been renamed to "legacy-access-om2-bgc".

--- a/packages/mom5/package.py
+++ b/packages/mom5/package.py
@@ -46,23 +46,28 @@ class Mom5(CMakePackage, MakefilePackage):
             "deterministic",
             default=False,
             description="Deterministic build",
-            when="@access-om2,legacy-access-om2-bgc,access-esm1.6"
+            when="@access-om2,legacy-access-om2-bgc"
         )
         variant(
             "optimisation_report",
             default=False,
             description="Generate optimisation reports",
-            when="@access-om2,legacy-access-om2-bgc,access-esm1.6"
+            when="@access-om2,legacy-access-om2-bgc"
         )
 
     with when("@mom,access-om2,legacy-access-om2-bgc,access-esm1.6"):
         depends_on("netcdf-c@4.7.4:")
         depends_on("netcdf-fortran@4.5.2:")
+        # Depend on virtual package "mpi".
         depends_on("mpi")
 
-    with when("@access-om2,legacy-access-om2-bgc,access-esm1.6"):
+    with when("@access-om2,legacy-access-om2-bgc"):
         depends_on("oasis3-mct+deterministic", when="+deterministic")
         depends_on("oasis3-mct~deterministic", when="~deterministic")
+
+    with when("@access-esm1.6"):
+        depends_on("oasis3-mct@access-esm1.5+deterministic", when="+deterministic")
+        depends_on("oasis3-mct@access-esm1.5~deterministic", when="~deterministic")
 
     with when("@access-om2,legacy-access-om2-bgc"):
         depends_on("datetime-fortran")
@@ -75,6 +80,8 @@ class Mom5(CMakePackage, MakefilePackage):
         depends_on("access-fms")
         depends_on("access-generic-tracers")
 
+    # legacy-access-om2-bgc builds with access-generic-tracers but it
+    # is not configured for use in ACCESS-OM2-BGC configurations.
     with when("@legacy-access-om2-bgc"):
         depends_on("access-fms", when="build_system=cmake")
         depends_on("access-generic-tracers", when="build_system=cmake")
@@ -639,3 +646,4 @@ TMPFILES = .*.m *.T *.TT *.hpm *.i *.lst *.proc *.s
             prefix.bin
         )
         install(join_path("bin", "mppnccombine." + self.__platform), prefix.bin)
+


### PR DESCRIPTION
This PR updates the mom5 SPR for the [new CMake build system](https://github.com/ACCESS-NRI/MOM5/pull/39).

~Currently I have completely dropped support for the `access-esm1.5` version. We need to discuss how we want to handle this version since it is built from a different branch and is not built with CMake.~ UPDATE: no longer true. This SPR now supports two build systems:

Makefile build supporting:
- access-esm1.5
- access-om2
-  legacy-access-om2-bgc

CMake build supporting:
- mom_solo
- mom_sis
- access-om2
- legacy-access-om2-bgc
- access-esm1.6

Build will default to CMake where possible