### PR TITLE
access-om3 SPRs: use build_system_flags as the flag handler

### DIFF
--- a/packages/access-cice/package.py
+++ b/packages/access-cice/package.py
@@ -40,6 +40,8 @@ class AccessCice(CMakePackage):
 
     root_cmakelists_dir = "configuration/scripts/cmake"
 
+    flag_handler = build_system_flags
+
     def cmake_args(self):
         args = [
             self.define_from_variant("CICE_OPENMP", "openmp"),

--- a/packages/access-mom6/package.py
+++ b/packages/access-mom6/package.py
@@ -37,6 +37,7 @@ class AccessMom6(CMakePackage):
     depends_on("fms +openmp", when="+openmp")
     depends_on("fms ~openmp", when="~openmp")
 
+    flag_handler = build_system_flags
 
     def cmake_args(self):
         args = [

--- a/packages/access-ww3/package.py
+++ b/packages/access-ww3/package.py
@@ -27,6 +27,8 @@ class AccessWw3(CMakePackage):
     depends_on("mpi")
     depends_on("netcdf-fortran@4.6.0:")
 
+    flag_handler = build_system_flags
+
     def cmake_args(self):
         args = [
             self.define_from_variant("WW3_OPENMP", "openmp"),

--- a/packages/access3-share/package.py
+++ b/packages/access3-share/package.py
@@ -33,6 +33,8 @@ class Access3Share(CMakePackage):
                 "cflags='-qno-opt-dynamic-align -fp-model precise -std=gnu99'"),
                 when="%intel")  # consistency with access-om3-nuopc builds, e.g. https://github.com/ACCESS-NRI/spack-packages/blob/e2bdb46e56af8ac14183e7ed25da9235486c973a/packages/access-om3-nuopc/package.py#L65
 
+    flag_handler = build_system_flags
+
     def cmake_args(self):
         args = [
             self.define("ACCESS3_LIB_INSTALL", True),

--- a/packages/access3/package.py
+++ b/packages/access3/package.py
@@ -60,6 +60,8 @@ class Access3(CMakePackage):
         if "WW3" in conf:
             depends_on("access-ww3+access3", when=f"configurations={conf}")
 
+    flag_handler = build_system_flags
+
     def cmake_args(self):
         # make configurations a cmake argument
         buildConf = ";".join(self.spec.variants["configurations"].value)


### PR DESCRIPTION
* The default flag_handler is inject_flags. This method is opaque and verifying whether the flags were applied is difficult.
* Setting the flag_handler to build_system_flags should result in the flags appearing in the package's build logs.