### PR TITLE
Autotools & CMake SPRs: use build_system_flags as the flag handler

### DIFF
--- a/packages/access-fms/package.py
+++ b/packages/access-fms/package.py
@@ -40,6 +40,8 @@ class AccessFms(CMakePackage):
     depends_on("netcdf-fortran")
     depends_on("mpi")
 
+    flag_handler = build_system_flags
+
     def url_for_version(self, version):
         return "https://github.com/ACCESS-NRI/FMS/tarball/{0}".format(version)
 

--- a/packages/access-generic-tracers/package.py
+++ b/packages/access-generic-tracers/package.py
@@ -25,6 +25,8 @@ class AccessGenericTracers(CMakePackage):
     depends_on("access-fms")
     depends_on("mpi")
 
+    flag_handler = build_system_flags
+
     def url_for_version(self, version):
         return "https://github.com/ACCESS-NRI/GFDL-generic-tracers/tarball/{0}".format(version)
 

--- a/packages/access-test-component/package.py
+++ b/packages/access-test-component/package.py
@@ -28,5 +28,7 @@ class AccessTestComponent(CMakePackage):
 
     root_cmakelists_dir = "stub"
 
+    flag_handler = build_system_flags
+
     def url_for_version(self, version):
         return f"https://github.com/{self.githubrepo}/tarball/{version}"

--- a/packages/cable/package.py
+++ b/packages/cable/package.py
@@ -46,6 +46,8 @@ class Cable(CMakePackage):
     depends_on("netcdf-fortran@4.5.2:")
     depends_on("mpi", when="+mpi")
 
+    flag_handler = build_system_flags
+
     def cmake_args(self):
         args = []
         args.append(self.define_from_variant("CABLE_MPI", "mpi"))

--- a/packages/datetime-fortran/package.py
+++ b/packages/datetime-fortran/package.py
@@ -41,6 +41,8 @@ class DatetimeFortran(AutotoolsPackage):
 
     patch("0001-Enable-deterministic-builds-using-D-flag-for-ar.patch", when="@1.7.0")
 
+    flag_handler = build_system_flags
+
     def url_for_version(self, version):
         return "https://github.com/wavebitscientific/datetime-fortran/releases/download/v{0}/datetime-fortran-{0}.tar.gz".format(version)
 

--- a/packages/fiat/package.py
+++ b/packages/fiat/package.py
@@ -45,6 +45,8 @@ class Fiat(CMakePackage):
     patch("intel_warnings_v110.patch", when="@0:1.1.0")
     patch("intel_warnings_v120.patch", when="@1.2.0:")
 
+    flag_handler = build_system_flags
+
     def cmake_args(self):
         args = [
             self.define_from_variant("ENABLE_OMP", "openmp"),

--- a/packages/fortranxml/package.py
+++ b/packages/fortranxml/package.py
@@ -19,7 +19,7 @@ class Fortranxml(AutotoolsPackage):
 
     version("4.1.2", sha256="1938725be45b8be5387a51fa0b25ee78ffee87ca8a497b82545ab870f33f8b88")
 
-    flag_handler = AutotoolsPackage.build_system_flags
+    flag_handler = build_system_flags
 
     def url_for_version(self, version):
         return "https://github.com/andreww/fox/tarball/{0}".format(version)

--- a/packages/fre-nctools/package.py
+++ b/packages/fre-nctools/package.py
@@ -46,6 +46,8 @@ class FreNctools(AutotoolsPackage):
     depends_on("mpi", when="+mpi")
     depends_on("nco", when="@2024.05:")
 
+    flag_handler = build_system_flags
+
     def url_for_version(self, version):
         return "https://github.com/NOAA-GFDL/FRE-NCtools/archive/{0}.tar.gz".format(version)
 

--- a/packages/issm/package.py
+++ b/packages/issm/package.py
@@ -46,6 +46,8 @@ class Issm(AutotoolsPackage):
     depends_on("python@3.9.2:", when="+wrappers", type=("build", "run"))
     depends_on("py-numpy", when="+wrappers", type=("build", "run"))
 
+    flag_handler = build_system_flags
+
     def url_for_version(self, version):
         if version == Version("upstream"):
             return "https://github.com/ISSMteam/ISSM/archive/refs/heads/main.tar.gz"

--- a/packages/libaccessom2/package.py
+++ b/packages/libaccessom2/package.py
@@ -35,6 +35,8 @@ class Libaccessom2(CMakePackage):
     depends_on("json-fortran")
     depends_on("netcdf-fortran@4.5.2:")
 
+    flag_handler = build_system_flags
+
     def url_for_version(self, version):
         return "https://github.com/ACCESS-NRI/libaccessom2/tarball/{0}".format(version)
 


### PR DESCRIPTION
* The default flag_handler is inject_flags. This method is opaque
   and verifying whether the flags were applied is difficult.
* Setting the flag_handler to build_system_flags should result in the
   flags appearing in the package's CMake build logs.
