### PR TITLE
Add access-generic-tracers as a dependency of access-mom6

### DIFF
--- a/packages/access-generic-tracers/package.py
+++ b/packages/access-generic-tracers/package.py
@@ -21,8 +21,15 @@ class AccessGenericTracers(CMakePackage):
     # TODO: Needs to be changed once changes to build system enter master.
     version("development", branch="development", preferred=True)
 
+    variant(
+        "use_access_fms",
+        default=True,
+        description="If True, depend on access-fms, otherwise depend on fms"
+    )
+
     depends_on("access-mocsy")
-    depends_on("access-fms")
+    depends_on("access-fms", when="+use_access_fms")
+    depends_on("fms", when="~use_access_fms")
     depends_on("mpi")
 
     def url_for_version(self, version):

--- a/packages/access-mom6/package.py
+++ b/packages/access-mom6/package.py
@@ -36,6 +36,7 @@ class AccessMom6(CMakePackage):
     depends_on("fms@2023.02: precision=64 +large_file ~gfs_phys ~quad_precision")
     depends_on("fms +openmp", when="+openmp")
     depends_on("fms ~openmp", when="~openmp")
+    depends_on("access-generic-tracers ~use_access_fms")
 
     flag_handler = build_system_flags
 


### PR DESCRIPTION
This PR adds `access-generic-tracers` as a dependency of `access-mom6`. It also adds a variant to the `access-generic-tracers` SPR to allow switching between depending on `access-fms` or `fms`. This defaults to `access-fms` for backwards compatibility.

Depends on:
- https://github.com/ACCESS-NRI/MOM6/pull/10