### PR TITLE
access-om3 main dependencies: add versions and specify min versions

### DIFF
--- a/packages/access-cice/package.py
+++ b/packages/access-cice/package.py
@@ -19,6 +19,9 @@ class AccessCice(CMakePackage):
     # see license file at https://github.com/CICE-Consortium/CICE
     license("LicenseRef-CICE", checked_by="anton-seaice")
 
+    version("CICE6.6.0-3", commit="2c444bd")
+    version("CICE6.6.0-1", commit="964a445")
+
     variant("openmp", default=False, description="Enable OpenMP")
     variant(
         "access3",

--- a/packages/access-generic-tracers/package.py
+++ b/packages/access-generic-tracers/package.py
@@ -21,6 +21,8 @@ class AccessGenericTracers(CMakePackage):
     # TODO: Needs to be changed once changes to build system enter master.
     version("development", branch="development", preferred=True)
 
+    # NOTE: access-fms@mom5 should be used in OM2, ESM1.5 and ESM1.6 to preserve
+    # answers with previous releases
     variant(
         "use_access_fms",
         default=True,

--- a/packages/access-generic-tracers/package.py
+++ b/packages/access-generic-tracers/package.py
@@ -29,7 +29,7 @@ class AccessGenericTracers(CMakePackage):
 
     depends_on("access-mocsy")
     depends_on("access-fms", when="+use_access_fms")
-    depends_on("fms", when="~use_access_fms")
+    depends_on("fms@2025.02:", when="~use_access_fms")
     depends_on("mpi")
 
     flag_handler = build_system_flags

--- a/packages/access-mom6/package.py
+++ b/packages/access-mom6/package.py
@@ -36,7 +36,7 @@ class AccessMom6(CMakePackage):
     depends_on("fms@2023.02: precision=64 +large_file ~gfs_phys ~quad_precision")
     depends_on("fms +openmp", when="+openmp")
     depends_on("fms ~openmp", when="~openmp")
-    depends_on("access-generic-tracers ~use_access_fms")
+    depends_on("access-generic-tracers ~use_access_fms", when="@2025.02.001:")
 
     flag_handler = build_system_flags
 

--- a/packages/access-mom6/package.py
+++ b/packages/access-mom6/package.py
@@ -21,6 +21,9 @@ class AccessMom6(CMakePackage):
     # see license file in https://github.com/ACCESS-NRI/MOM6/blob/e92c971084e185cfd3902f18072320b45d583a54/LICENSE.md
     license("LGPL-3.0-only", checked_by="minghangli-uni")
 
+    version("2025.02.001", commit="a5f4397")
+    version("2025.02.000", commit="e088c8b")
+
     variant("openmp", default=False, description="Enable OpenMP")
     variant("asymmetric_mem", default=False, description="Use asymmetric memory in MOM6")
     variant(

--- a/packages/access-mom6/package.py
+++ b/packages/access-mom6/package.py
@@ -37,7 +37,7 @@ class AccessMom6(CMakePackage):
     depends_on("mpi")
     depends_on("netcdf-fortran@4.6.0:")
     depends_on("fms@2023.02: precision=64 +large_file ~gfs_phys ~quad_precision")
-    depends_on("fms +openmp", when="+openmp")
+    depends_on("fms@2025.02: +openmp", when="+openmp")
     depends_on("fms ~openmp", when="~openmp")
     depends_on("access-generic-tracers ~use_access_fms", when="@2025.02.001:")
 

--- a/packages/access-ww3/package.py
+++ b/packages/access-ww3/package.py
@@ -15,6 +15,8 @@ class AccessWw3(CMakePackage):
     maintainers("anton-seaice", "harshula")
     license("LGPL-3.0-only", checked_by="anton-seaice")
 
+    version("2025.03.0", commit="d980dec")
+
     variant("openmp", default=False, description="Enable OpenMP")
     variant(
         "access3",

--- a/packages/access3-share/package.py
+++ b/packages/access3-share/package.py
@@ -18,6 +18,9 @@ class Access3Share(CMakePackage):
     maintainers("anton-seaice", "harshula", "micaeljtoliveira")
     license("Apache-2.0", checked_by="anton-seaice")
 
+    version("2025.03.1", commit="d28d8b3")
+    version("2025.03.0", commit="d61a88a")
+
     variant("openmp", default=False, description="Enable OpenMP")
 
     depends_on("cmake@3.18:", type="build")

--- a/packages/access3/package.py
+++ b/packages/access3/package.py
@@ -28,6 +28,9 @@ class Access3(CMakePackage):
     maintainers("anton-seaice", "harshula", "micaeljtoliveira")
     license("Apache-2.0", checked_by="anton-seaice")
 
+    version("2025.03.1", commit="d28d8b3")
+    version("2025.03.0", commit="d61a88a")
+
     variant(
         "configurations",
         values=(*KNOWN_CONF, 'none'),
@@ -54,11 +57,11 @@ class Access3(CMakePackage):
 
     for conf in KNOWN_CONF:
         if "CICE6" in conf:
-            depends_on("access-cice+access3", when=f"configurations={conf}")
+            depends_on("access-cice@CICE6.6.0-1: +access3", when=f"configurations={conf}")
         if "MOM6" in conf:
-            depends_on("access-mom6+access3", when=f"configurations={conf}")
+            depends_on("access-mom6@2025.02.000: +access3", when=f"configurations={conf}")
         if "WW3" in conf:
-            depends_on("access-ww3+access3", when=f"configurations={conf}")
+            depends_on("access-ww3@2025.03.0: +access3", when=f"configurations={conf}")
 
     flag_handler = build_system_flags
 


### PR DESCRIPTION
This PR sets the minimum FMS version in the access-generic-tracers package to 2025.02. This to include the export of FindNetCDF.cmake in the FMS cmake install dir. Thanks to @anton-seaice for catching this [here](https://github.com/ACCESS-NRI/spack-packages/pull/241#discussion_r2090350755).

ADDED:
In addition, this PR 
- adds versions to the `access-cice`, `access-mom6`, `access-ww3`, `access3-share` and `access3` SPRs
- specifies min versions of `access-cice`, `access-mom6`, `access-ww3` in the `access3` SPR

`access-generic-tracers` and `access-mocsy` are still in development. Versions will be added in a subsequent PR.