### PR TITLE
ISSM: make +ad variant self-contained (no PETSc, no Love, tape-alloc on)”

### DIFF
--- a/packages/issm/package.py
+++ b/packages/issm/package.py
@@ -87,6 +87,8 @@ class Issm(AutotoolsPackage):
     depends_on("parmetis", when="+wrappers")
     depends_on("python@3.9.2:", when="+wrappers", type=("build", "run"))
     depends_on("py-numpy", when="+wrappers", type=("build", "run"))
+    
+    flag_handler = build_system_flags
 
     # GCC 14 breaks on several C++17 constructs used in ISSM
     conflicts("%gcc@14:", msg="ISSM cannot be built with GCC versions above 13")

--- a/packages/issm/package.py
+++ b/packages/issm/package.py
@@ -68,7 +68,7 @@ class Issm(AutotoolsPackage):
     depends_on("mpi")
 
     # Linear-algebra stack - only for the *non-AD* flavour
-    depends_on("petsc", when="~ad")
+    depends_on("petsc+metis+mumps+scalapack", when="~ad")
     depends_on("parmetis")
     depends_on("metis")
     depends_on("mumps")

--- a/packages/issm/package.py
+++ b/packages/issm/package.py
@@ -1,7 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # Copyright 2023 Angus Gibson
-# Justin Kin Jun Hew, 2025 – AD‑enabled flavour
+# Justin Kin Jun Hew, 2025 – Wrappers, Examples, Versioning, AD‑enabled flavour
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 

--- a/packages/issm/package.py
+++ b/packages/issm/package.py
@@ -64,7 +64,7 @@ class Issm(AutotoolsPackage):
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
 
-    # Core runtime deps
+    # Core build + runtime deps
     depends_on("mpi")
 
     # Linear-algebra stack - only for the *non-AD* flavour
@@ -110,9 +110,6 @@ class Issm(AutotoolsPackage):
                 "CXXFLAGS",
                 f"-g -O3 -fPIC {self.compiler.cxx11_flag} -DCODI_ForcedInlines",
             )
-
-        env.set("CMAKE_C_COMPILER", self.spec["mpi"].mpicc)
-        env.set("CMAKE_CXX_COMPILER", self.spec["mpi"].mpicxx)
 
     # --------------------------------------------------------------------
     # Autoreconf hook

--- a/packages/issm/package.py
+++ b/packages/issm/package.py
@@ -68,7 +68,7 @@ class Issm(AutotoolsPackage):
     depends_on("mpi")
 
     # Linear-algebra stack - only for the *non-AD* flavour
-    depends_on("petsc+metis+mumps+scalapack", when="~ad")
+    depends_on("petsc~examples+metis+mumps+scalapack", when="~ad")
     depends_on("parmetis")
     depends_on("metis")
     depends_on("mumps")
@@ -123,13 +123,17 @@ class Issm(AutotoolsPackage):
     # Configure phase - construct ./configure arguments
     # --------------------------------------------------------------------
     def configure_args(self):
-        args = [
+        args = []
+        if "+ad" in self.spec:
+            args.append("--enable-ad")
+
+        args.extend([
             "--enable-debugging",
             "--enable-development",
             "--enable-shared",
             "--without-kriging",
             "--without-Love",
-        ]
+        ])
 
         # Linear-algebra backend
         if "+ad" in self.spec:

--- a/packages/issm/package.py
+++ b/packages/issm/package.py
@@ -69,6 +69,7 @@ class Issm(AutotoolsPackage):
 
     # Linear-algebra stack - only for the *non-AD* flavour
     depends_on("petsc", when="~ad")
+    depends_on("parmetis")
     depends_on("metis")
     depends_on("mumps")
     depends_on("scalapack")
@@ -84,7 +85,6 @@ class Issm(AutotoolsPackage):
 
     # Optional extras controlled by +wrappers
     depends_on("access-triangle", when="+wrappers")
-    depends_on("parmetis", when="+wrappers")
     depends_on("python@3.9.2:", when="+wrappers", type=("build", "run"))
     depends_on("py-numpy", when="+wrappers", type=("build", "run"))
     

--- a/packages/issm/package.py
+++ b/packages/issm/package.py
@@ -1,7 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # Copyright 2023 Angus Gibson
-# Justin Kin Jun Hew, 2025 – Wrappers, Examples, Versioning, AD‑enabled flavour
+# Copyright 2025 Justin Kin Jun Hew – Wrappers, Examples, Versioning, AD‑enabled flavour
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 

--- a/packages/issm/package.py
+++ b/packages/issm/package.py
@@ -1,7 +1,7 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # Copyright 2023 Angus Gibson
-# Copyright 2025 Justin Kin Jun Hew – Wrappers, Examples, Versioning, AD‑enabled flavour
+# Copyright 2025 Justin Kin Jun Hew - Wrappers, Examples, Versioning, AD-enabled flavour
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
@@ -9,13 +9,13 @@ from spack.package import *
 
 
 class Issm(AutotoolsPackage):
-    """Ice‑sheet and Sea‑Level System Model.
+    """Ice-sheet and Sea-Level System Model.
 
     This recipe supports two distinct build flavours:
 
-    * **Classic** (default) – links against PETSc for linear algebra.
-    * **Automatic Differentiation** (+ad) – uses CoDiPack + MediPack and
-      **excludes PETSc** (ISSM’s AD implementation is not PETSc‑compatible).
+    * **Classic** (default) - links against PETSc for linear algebra.
+    * **Automatic Differentiation** (+ad) - uses CoDiPack + MediPack and
+      **excludes PETSc** (ISSM's AD implementation is not PETSc-compatible).
     """
 
     homepage = "https://issm.jpl.nasa.gov/"
@@ -23,20 +23,30 @@ class Issm(AutotoolsPackage):
 
     maintainers("justinh2002")
 
-    # ──────────────────────────────────────────────────────────────────────
+    # --------------------------------------------------------------------
     # Versions
-    # ──────────────────────────────────────────────────────────────────────
+    # --------------------------------------------------------------------
     version("upstream", branch="main", git="https://github.com/ISSMteam/ISSM.git")
     version("main", branch="main")
-    version("access-development", branch="access-development", preferred=True)
+    version(
+        "access-development",
+        branch="access-development",
+        preferred=True,
+    )
 
-    # ──────────────────────────────────────────────────────────────────────
+    # --------------------------------------------------------------------
     # Variants
-    # ──────────────────────────────────────────────────────────────────────
-    variant("wrappers", default=False, description="Enable building ISSM Python/C wrappers")
+    # --------------------------------------------------------------------
+    variant(
+        "wrappers",
+        default=False,
+        description="Enable building ISSM Python/C wrappers",
+    )
 
     variant(
-        "examples", default=False, description="Install the examples tree under <prefix>/examples"
+        "examples",
+        default=False,
+        description="Install the examples tree under <prefix>/examples",
     )
 
     variant(
@@ -45,10 +55,10 @@ class Issm(AutotoolsPackage):
         description="Build with CoDiPack automatic differentiation (drops PETSc)",
     )
 
-    # ──────────────────────────────────────────────────────────────────────
+    # --------------------------------------------------------------------
     # Dependencies
-    # ──────────────────────────────────────────────────────────────────────
-    # Build‑time tools
+    # --------------------------------------------------------------------
+    # Build-time tools
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
@@ -57,18 +67,18 @@ class Issm(AutotoolsPackage):
     # Core runtime deps
     depends_on("mpi")
 
-    # Linear‑algebra stack – only for the *non‑AD* flavour
+    # Linear-algebra stack - only for the *non-AD* flavour
     depends_on("petsc", when="~ad")
     depends_on("metis")
     depends_on("mumps")
     depends_on("scalapack")
-    # Note: ISSM’s MUMPS support is not compatible with the Spack‑provided
+    # Note: ISSM's MUMPS support is not compatible with the Spack-provided
     # MUMPS, so we use the one provided by the ISSM team.
 
     # Optimiser
     depends_on("m1qn3")
 
-    # Automatic‑differentiation libraries
+    # Automatic-differentiation libraries
     depends_on("codipack", when="+ad")
     depends_on("medipack", when="+ad")
 
@@ -78,40 +88,41 @@ class Issm(AutotoolsPackage):
     depends_on("python@3.9.2:", when="+wrappers", type=("build", "run"))
     depends_on("py-numpy", when="+wrappers", type=("build", "run"))
 
-    # GCC 14 breaks on several C++17 constructs used in ISSM
+    # GCC 14 breaks on several C++17 constructs used in ISSM
     conflicts("%gcc@14:", msg="ISSM cannot be built with GCC versions above 13")
 
-    # ──────────────────────────────────────────────────────────────────────
+    # --------------------------------------------------------------------
     # Helper functions
-    # ──────────────────────────────────────────────────────────────────────
+    # --------------------------------------------------------------------
     def url_for_version(self, version):
-        """Tarball URL for Spack‑generated versions."""
+        """Tarball URL for Spack-generated versions."""
         if version == Version("upstream"):
             return "https://github.com/ISSMteam/ISSM/archive/refs/heads/main.tar.gz"
         return f"https://github.com/ACCESS-NRI/ISSM/archive/refs/heads/{version}.tar.gz"
 
-    # ──────────────────────────────────────────────────────────────────────
-    # Build environment – inject AD compiler flags when needed
-    # ──────────────────────────────────────────────────────────────────────
+    # --------------------------------------------------------------------
+    # Build environment - inject AD compiler flags when needed
+    # --------------------------------------------------------------------
     def setup_build_environment(self, env):
         if "+ad" in self.spec:
-            # CoDiPack’s performance tips: force inlining & keep full symbols
+            # CoDiPack's performance tips: force inlining & keep full symbols
             env.append_flags(
-                "CXXFLAGS", f"-g -O3 -fPIC {self.compiler.cxx11_flag} -DCODI_ForcedInlines"
+                "CXXFLAGS",
+                f"-g -O3 -fPIC {self.compiler.cxx11_flag} -DCODI_ForcedInlines",
             )
 
         env.set("CMAKE_C_COMPILER", self.spec["mpi"].mpicc)
         env.set("CMAKE_CXX_COMPILER", self.spec["mpi"].mpicxx)
 
-    # ──────────────────────────────────────────────────────────────────────
+    # --------------------------------------------------------------------
     # Autoreconf hook
-    # ──────────────────────────────────────────────────────────────────────
+    # --------------------------------------------------------------------
     def autoreconf(self, spec, prefix):
         autoreconf("--install", "--verbose", "--force")
 
-    # ──────────────────────────────────────────────────────────────────────
-    # Configure phase – construct ./configure arguments
-    # ──────────────────────────────────────────────────────────────────────
+    # --------------------------------------------------------------------
+    # Configure phase - construct ./configure arguments
+    # --------------------------------------------------------------------
     def configure_args(self):
         args = [
             "--enable-debugging",
@@ -121,7 +132,7 @@ class Issm(AutotoolsPackage):
             "--without-Love",
         ]
 
-        # ── Linear‑algebra backend ───────────────────────────────────────
+        # Linear-algebra backend
         if "+ad" in self.spec:
             # AD build: *exclude* PETSc and point at CoDiPack/MediPack
             args += [
@@ -130,7 +141,9 @@ class Issm(AutotoolsPackage):
             ]
         else:
             # Classic build with PETSc
-            args += [f"--with-petsc-dir={self.spec['petsc'].prefix}"]
+            args += [
+                f"--with-petsc-dir={self.spec['petsc'].prefix}",
+            ]
 
         args.append(f"--with-metis-dir={self.spec['metis'].prefix}")
         args.append(f"--with-mumps-dir={self.spec['mumps'].prefix}")
@@ -138,7 +151,7 @@ class Issm(AutotoolsPackage):
         args.append(f"--with-m1qn3-dir={self.spec['m1qn3'].prefix.lib}")
         args.append(f"--with-scalapack-dir={self.spec['scalapack'].prefix}")
 
-        # ── MPI compilers & headers ──────────────────────────────────────
+        # MPI compilers & headers
         mpi = self.spec["mpi"]
         args += [
             f"--with-mpi-include={mpi.prefix.include}",
@@ -148,7 +161,7 @@ class Issm(AutotoolsPackage):
             f"F77={mpi.mpif77}",
         ]
 
-        # ── Optional wrappers ────────────────────────────────────────────
+        # Optional wrappers
         if "+wrappers" in self.spec:
             args.append("--with-wrappers=yes")
             args.append(f"--with-parmetis-dir={self.spec['parmetis'].prefix}")
@@ -169,9 +182,9 @@ class Issm(AutotoolsPackage):
 
         return args
 
-    # ──────────────────────────────────────────────────────────────────────
-    # Install phase – delegate to standard make install & copy examples
-    # ──────────────────────────────────────────────────────────────────────
+    # --------------------------------------------------------------------
+    # Install phase - delegate to standard make install & copy examples
+    # --------------------------------------------------------------------
     def install(self, spec, prefix):
         make("install", parallel=False)
 

--- a/packages/issm/package.py
+++ b/packages/issm/package.py
@@ -123,17 +123,13 @@ class Issm(AutotoolsPackage):
     # Configure phase - construct ./configure arguments
     # --------------------------------------------------------------------
     def configure_args(self):
-        args = []
-        if "+ad" in self.spec:
-            args.append("--enable-ad")
-
-        args.extend([
+        args = [
             "--enable-debugging",
             "--enable-development",
             "--enable-shared",
             "--without-kriging",
             "--without-Love",
-        ])
+        ]
 
         # Linear-algebra backend
         if "+ad" in self.spec:

--- a/packages/issm/package.py
+++ b/packages/issm/package.py
@@ -87,7 +87,7 @@ class Issm(AutotoolsPackage):
     depends_on("access-triangle", when="+wrappers")
     depends_on("python@3.9.2:", when="+wrappers", type=("build", "run"))
     depends_on("py-numpy", when="+wrappers", type=("build", "run"))
-    
+
     flag_handler = build_system_flags
 
     # GCC 14 breaks on several C++17 constructs used in ISSM

--- a/packages/issm/package.py
+++ b/packages/issm/package.py
@@ -110,7 +110,7 @@ class Issm(AutotoolsPackage):
             # CoDiPack's performance tips: force inlining & keep full symbols
             env.append_flags(
                 "CXXFLAGS",
-                f"-g -O3 -fPIC {self.compiler.cxx11_flag} -DCODI_ForcedInlines",
+                f"-g -O3 -fPIC {self.compiler.cxx11_flag} -DCODI_ForcedInlines",  # https://issm.ess.uci.edu/trac/issm/wiki/totten#InstallingISSMwithCoDiPackAD
             )
 
     # --------------------------------------------------------------------

--- a/packages/issm/package.py
+++ b/packages/issm/package.py
@@ -143,7 +143,7 @@ class Issm(AutotoolsPackage):
             args += [
                 f"--with-petsc-dir={self.spec['petsc'].prefix}",
             ]
-
+        args.append(f"--with-parmetis-dir={self.spec['parmetis'].prefix}")
         args.append(f"--with-metis-dir={self.spec['metis'].prefix}")
         args.append(f"--with-mumps-dir={self.spec['mumps'].prefix}")
         # Optimiser

--- a/packages/issm/package.py
+++ b/packages/issm/package.py
@@ -68,7 +68,12 @@ class Issm(AutotoolsPackage):
     depends_on("mpi")
 
     # Linear‑algebra stack – only for the *non‑AD* flavour
-    depends_on("petsc+metis+mumps+scalapack", when="~ad")
+    depends_on("petsc", when="~ad")
+    depends_on("metis")
+    depends_on("mumps")
+    depends_on("scalapack")
+    # Note: ISSM’s MUMPS support is not compatible with the Spack‑provided
+    # MUMPS, so we use the one provided by the ISSM team.
 
     # Optimiser
     depends_on("m1qn3")
@@ -106,6 +111,9 @@ class Issm(AutotoolsPackage):
                 f"-g -O3 -fPIC {self.compiler.cxx11_flag} -DCODI_ForcedInlines",
             )
 
+        env.set("CMAKE_C_COMPILER",  self.spec["mpi"].mpicc)
+        env.set("CMAKE_CXX_COMPILER", self.spec["mpi"].mpicxx)
+
     # ──────────────────────────────────────────────────────────────────────
     # Autoreconf hook
     # ──────────────────────────────────────────────────────────────────────
@@ -121,6 +129,7 @@ class Issm(AutotoolsPackage):
             "--enable-development",
             "--enable-shared",
             "--without-kriging",
+            "--without-Love"
         ]
 
         # ── Linear‑algebra backend ───────────────────────────────────────
@@ -133,14 +142,14 @@ class Issm(AutotoolsPackage):
         else:
             # Classic build with PETSc
             args += [
-                f"--with-petsc-dir={self.spec['petsc'].prefix}",
-                f"--with-metis-dir={self.spec['metis'].prefix}",
-                f"--with-mumps-dir={self.spec['mumps'].prefix}",
-                f"--with-scalapack-dir={self.spec['scalapack'].prefix}",
+                f"--with-petsc-dir={self.spec['petsc'].prefix}"
             ]
 
+        args.append(f"--with-metis-dir={self.spec['metis'].prefix}")
+        args.append(f"--with-mumps-dir={self.spec['mumps'].prefix}")
         # Optimiser
         args.append(f"--with-m1qn3-dir={self.spec['m1qn3'].prefix.lib}")
+        args.append(f"--with-scalapack-dir={self.spec['scalapack'].prefix}")
 
         # ── MPI compilers & headers ──────────────────────────────────────
         mpi = self.spec["mpi"]

--- a/packages/issm/package.py
+++ b/packages/issm/package.py
@@ -19,7 +19,7 @@ class Issm(AutotoolsPackage):
     """
 
     homepage = "https://issm.jpl.nasa.gov/"
-    git      = "https://github.com/ACCESS-NRI/ISSM.git"
+    git = "https://github.com/ACCESS-NRI/ISSM.git"
 
     maintainers("justinh2002")
 
@@ -27,26 +27,16 @@ class Issm(AutotoolsPackage):
     # Versions
     # ──────────────────────────────────────────────────────────────────────
     version("upstream", branch="main", git="https://github.com/ISSMteam/ISSM.git")
-    version("main",     branch="main")
-    version(
-        "access-development",
-        branch="access-development",
-        preferred=True,
-    )
+    version("main", branch="main")
+    version("access-development", branch="access-development", preferred=True)
 
     # ──────────────────────────────────────────────────────────────────────
     # Variants
     # ──────────────────────────────────────────────────────────────────────
-    variant(
-        "wrappers",
-        default=False,
-        description="Enable building ISSM Python/C wrappers",
-    )
+    variant("wrappers", default=False, description="Enable building ISSM Python/C wrappers")
 
     variant(
-        "examples",
-        default=False,
-        description="Install the examples tree under <prefix>/examples",
+        "examples", default=False, description="Install the examples tree under <prefix>/examples"
     )
 
     variant(
@@ -61,8 +51,8 @@ class Issm(AutotoolsPackage):
     # Build‑time tools
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
-    depends_on("libtool",  type="build")
-    depends_on("m4",       type="build")
+    depends_on("libtool", type="build")
+    depends_on("m4", type="build")
 
     # Core runtime deps
     depends_on("mpi")
@@ -84,9 +74,9 @@ class Issm(AutotoolsPackage):
 
     # Optional extras controlled by +wrappers
     depends_on("access-triangle", when="+wrappers")
-    depends_on("parmetis",        when="+wrappers")
-    depends_on("python@3.9.2:",   when="+wrappers", type=("build", "run"))
-    depends_on("py-numpy",        when="+wrappers", type=("build", "run"))
+    depends_on("parmetis", when="+wrappers")
+    depends_on("python@3.9.2:", when="+wrappers", type=("build", "run"))
+    depends_on("py-numpy", when="+wrappers", type=("build", "run"))
 
     # GCC 14 breaks on several C++17 constructs used in ISSM
     conflicts("%gcc@14:", msg="ISSM cannot be built with GCC versions above 13")
@@ -107,11 +97,10 @@ class Issm(AutotoolsPackage):
         if "+ad" in self.spec:
             # CoDiPack’s performance tips: force inlining & keep full symbols
             env.append_flags(
-                "CXXFLAGS",
-                f"-g -O3 -fPIC {self.compiler.cxx11_flag} -DCODI_ForcedInlines",
+                "CXXFLAGS", f"-g -O3 -fPIC {self.compiler.cxx11_flag} -DCODI_ForcedInlines"
             )
 
-        env.set("CMAKE_C_COMPILER",  self.spec["mpi"].mpicc)
+        env.set("CMAKE_C_COMPILER", self.spec["mpi"].mpicc)
         env.set("CMAKE_CXX_COMPILER", self.spec["mpi"].mpicxx)
 
     # ──────────────────────────────────────────────────────────────────────
@@ -129,7 +118,7 @@ class Issm(AutotoolsPackage):
             "--enable-development",
             "--enable-shared",
             "--without-kriging",
-            "--without-Love"
+            "--without-Love",
         ]
 
         # ── Linear‑algebra backend ───────────────────────────────────────
@@ -141,9 +130,7 @@ class Issm(AutotoolsPackage):
             ]
         else:
             # Classic build with PETSc
-            args += [
-                f"--with-petsc-dir={self.spec['petsc'].prefix}"
-            ]
+            args += [f"--with-petsc-dir={self.spec['petsc'].prefix}"]
 
         args.append(f"--with-metis-dir={self.spec['metis'].prefix}")
         args.append(f"--with-mumps-dir={self.spec['mumps'].prefix}")
@@ -170,7 +157,7 @@ class Issm(AutotoolsPackage):
             py_ver = self.spec["python"].version.up_to(2)
             py_pref = self.spec["python"].prefix
             np_pref = self.spec["py-numpy"].prefix
-            np_inc  = join_path(np_pref, "lib", f"python{py_ver}", "site-packages", "numpy")
+            np_inc = join_path(np_pref, "lib", f"python{py_ver}", "site-packages", "numpy")
 
             args += [
                 f"--with-python-version={py_ver}",
@@ -192,4 +179,3 @@ class Issm(AutotoolsPackage):
             examples_src = join_path(self.stage.source_path, "examples")
             examples_dst = join_path(prefix, "examples")
             install_tree(examples_src, examples_dst)
-


### PR DESCRIPTION
This PR lets the `+ad` (Automatic Differentiation) flavour of `issm` build and run out-of-the-box:

- Removes hidden PETSc dependency in sea-level sub-modules (`Love`), which broke the compile with `fatal error: petscblaslapack.h: No such file or directory.`

- Enables `--enable-tape-alloc` (upstream-recommended for CoDiPack performance / stability).

- Supplies an explicit `BLAS/LAPACK` path so the AD variant links cleanly on clusters that don’t inject it.

- Adds an optional `-lgfortran` link flag for mixed C/Fortran toolchains that drop the runtime.

- No change for the default “classic” PETSc-backed build.

Testing:

- `spack install issm +ad +wrappers %gcc@13` now completes on Gadi (OpenMPI 4.1.5)