### PR TITLE
Convert `um7` and `gcom4` to https git URLs

### DIFF
--- a/packages/gcom4/package.py
+++ b/packages/gcom4/package.py
@@ -17,7 +17,7 @@ class Gcom4(Package):
     """
 
     homepage = "https://code.metoffice.gov.uk/trac/gcom"
-    git = "git@github.com:ACCESS-NRI/GCOM4.git"
+    git = "https://github.com/ACCESS-NRI/GCOM4.git"
 
     maintainers("penguian")
 
@@ -65,7 +65,7 @@ class Gcom4(Package):
                 r"-openmp", "-qopenmp",
                     join_path("fcm-make", "machines", f"{machine}.cfg"))
 
-            
+
     def build(self, spec, prefix):
         """
         Build the library.
@@ -99,4 +99,3 @@ class Gcom4(Package):
             join_path("build", "lib", "libgcom.a"),
             join_path(prefix.lib, "libgcom.a"))
         install_tree(join_path("build", "include"), prefix.include)
-

--- a/packages/um7/package.py
+++ b/packages/um7/package.py
@@ -17,7 +17,7 @@ class Um7(Package):
     """
 
     homepage = "https://code.metoffice.gov.uk/trac/um"
-    git = "git@github.com:ACCESS-NRI/UM7.git"
+    git = "https://github.com/ACCESS-NRI/UM7.git"
 
     # https://code.metoffice.gov.uk/trac/um/wiki/PastReleases
     version("access-esm1.6", branch="dev-access-esm1.6", preferred=True)
@@ -219,4 +219,3 @@ tool::ldflags                                      {FOBLANK} -g -traceback {FDEB
         install(
             join_path(self._bld_path, "bin", um_exe),
             join_path(prefix.bin, um_exe))
-


### PR DESCRIPTION
## Background

Currently, `um7` and `gcom4` packages use SSH-style `git` URLs. This is because they are private, and in `build-cd` are cloned via service user SSH key. 

SSH keys have the same access to organisations and repositories (private/public, read/write/admin) as the user that created them, and can't be made finer in scope. A better solution would be to use a fine-grained GitHub PAT, which can be reduced in scope as appropriate. 

In order to use fine-grained GitHub PATs (which are used over `https` rather than `ssh`) for these private repositories, we need to change the `git` URLs from the SSH-style to the https-style URLs. 

This will also allow `build-ci` to clone private repositories via fine-grained PAT rather than SSH Key. 

## This PR

- Convert `gcom4` package to `https`-style `git` URL
- Convert `um7` package to `https`-style `git` URL

## Testing

Verified that `gcom4` and `um7` are clonable via `spack install` when the appropriate token is supplied via git config, namely:

```
[url "https://git:github_pat_XXXXX@github.com/"]
        insteadOf = https://github.com/
```

A run of this in `build-ci` can be found here: https://github.com/ACCESS-NRI/MOM5/actions/runs/15868448933/job/44739640746#step:13:2349