### PR TITLE
mppnccombine-fast: Add SPR

### DIFF
--- a/packages/mppnccombine-fast/package.py
+++ b/packages/mppnccombine-fast/package.py
@@ -1,0 +1,28 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# Copyright 2025 ACCESS-NRI
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class MppnccombineFast(CMakePackage):
+    """mppnccombine-fast is a fast version of mppnccombine, a tool for combining
+    multiple netCDF files into a single file. It is designed to be used with
+    large datasets and provides significant performance improvements over the
+    standard mppnccombine."""
+
+    homepage = "https://github.com/coecms/mppnccombine-fast"
+    git = "https://github.com/ACCESS-NRI/mppnccombine-fast.git"
+    url = "https://github.com/ACCESS-NRI/mppnccombine-fast/archive/refs/tags/2025.07.000.tar.gz"
+    maintainers("dougiesquire")
+
+    license("Apache-2.0", checked_by="dougiesquire")
+
+    version("2025.07.000", sha256="d74ef9b47aa6a6aac2d2f802f146b59d585104a780b65571fe7fda78e69af553")
+
+    depends_on("cmake@3.10:", type="build")
+    depends_on("mpi")
+    depends_on("hdf5")
+    depends_on("netcdf-c")


### PR DESCRIPTION
This PR adds a SPR for [mppnccombine-fast](https://github.com/ACCESS-NRI/mppnccombine-fast)

Closes #74

### Testing on Gadi

```
$ spack install mppnccombine-fast %intel@2021.10.0
```
installs successfully and tests pass:
```
$ spack load mppnccombine-fast
$ module load conda openmpi/5.0.5
$ cd <mppnccombine-fast/src/dir>
$ pytest
================================================= test session starts ==================================================
platform linux -- Python 3.11.11, pytest-8.3.5, pluggy-1.5.0
rootdir: /g/data/tm70/ds0092/model/dev/mppnccombine-fast/mppnccombine-fast
plugins: hypothesis-6.117.0, cov-6.0.0
collected 15 items

test_mppnccombine.py ...............                                                                             [100%]

================================================= 15 passed in 56.17s ==================================================
```