### PR TITLE
access-generic-tracers: Update versions

### DIFF
--- a/packages/access-generic-tracers/package.py
+++ b/packages/access-generic-tracers/package.py
@@ -17,9 +17,9 @@ class AccessGenericTracers(CMakePackage):
 
     maintainers("harshula")
 
-    version("master", branch="master")
-    # TODO: Needs to be changed once changes to build system enter master.
-    version("development", branch="development", preferred=True)
+    version("main", branch="main", preferred=True)
+    # TODO: Delete development version once we're sure we're using main everywhere.
+    version("development", branch="development")
 
     variant(
         "shared",


### PR DESCRIPTION
This PR updates versions in the `access-generic-tracers` SPR. Specifically:
- Add version 2025.07.000
- Rename "master" version to "main" (default branch was renamed some months ago). I'm pretty confident this wasn't be used anywhere.
- Add note to delete the "development" version once we're confident it's not being used anywhere.