### PR TITLE
Add specific access3 package tests, with configuration variants

### DIFF
--- a/.github/build-ci/manifests/access3/gcc.spack.yaml.j2
+++ b/.github/build-ci/manifests/access3/gcc.spack.yaml.j2
@@ -1,0 +1,13 @@
+# This manifest is used by default for packages without a specific manifest under .github/build-ci/manifests/PACKAGE/*.j2
+spack:
+  specs:
+  # package is defined in the workflows inputs.spack-manifest-data-pairs
+  # And the gcc_compilers are defined in the standard_definitions.json data file
+  - '{{ package }} configurations=MOM6,CICE6,WW3,MOM6-WW3,MOM6-CICE6,CICE6-WW3,MOM6-CICE6-WW3 %{{ gcc_compiler }}'
+  packages:
+    all:
+      require:
+      - '%{{ gcc_compiler }}'
+  concretizer:
+    unify: false
+  view: false

--- a/.github/build-ci/manifests/access3/intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/access3/intel.spack.yaml.j2
@@ -1,0 +1,13 @@
+# This manifest is used by default for packages without a specific manifest under .github/build-ci/manifests/PACKAGE/*.j2
+spack:
+  specs:
+  # package is defined in the workflows inputs.spack-manifest-data-pairs
+  # And the intel_compilers are defined in the standard_definitions.json data file
+  - '{{ package }} configurations=MOM6,CICE6,WW3,MOM6-WW3,MOM6-CICE6,CICE6-WW3,MOM6-CICE6-WW3 %{{ intel_compiler }}'
+  packages:
+    all:
+      require:
+      - '%{{ intel_compiler }}'
+  concretizer:
+    unify: false
+  view: false


### PR DESCRIPTION
Closes #292

## Background

The `access3` package doesn't run with the default manifests, so we create specific `intel`/`gcc` ones with the `configurations` variant set. 

## The PR

* Add `access3`-specific manifests for testing
