### PR TITLE
Use oasis3-mct master branch in ACCESS-ESM1.6

### DIFF
--- a/packages/mom5/package.py
+++ b/packages/mom5/package.py
@@ -63,14 +63,12 @@ class Mom5(CMakePackage, MakefilePackage):
 
     with when("@access-om2,legacy-access-om2-bgc"):
         depends_on("datetime-fortran")
-        depends_on("oasis3-mct+deterministic", when="+deterministic")
-        depends_on("oasis3-mct~deterministic", when="~deterministic")
         depends_on("libaccessom2+deterministic", when="+deterministic")
         depends_on("libaccessom2~deterministic", when="~deterministic")
 
-    with when("@access-esm1.6"):
-        depends_on("oasis3-mct@access-esm1.5+deterministic", when="+deterministic")
-        depends_on("oasis3-mct@access-esm1.5~deterministic", when="~deterministic")
+    with when("@access-om2,legacy-access-om2-bgc,access-esm1.6"):
+        depends_on("oasis3-mct+deterministic", when="+deterministic")
+        depends_on("oasis3-mct~deterministic", when="~deterministic")
 
     # NOTE: Spack will also match "access-om2-legacy-bgc" here, that's why
     #       it has been renamed to "legacy-access-om2-bgc".

--- a/packages/oasis3-mct/package.py
+++ b/packages/oasis3-mct/package.py
@@ -17,25 +17,22 @@ class Oasis3Mct(MakefilePackage):
 
     maintainers("harshula", "penguian")
 
+    version("stable", branch="master", preferred=True)
     version(
         "upstream",
         branch="OASIS3-MCT_5.0",
         git="https://gitlab.com/cerfacs/oasis3-mct.git",
     )
-    version("access-om2", branch="master", preferred=True)
+    # TODO: Remove the "access-om2" once it is no longer being used anywhere
+    version("access-om2", branch="master")
     version("access-esm1.5", branch="access-esm1.5")
 
     variant("deterministic", default=False, description="Deterministic build.")
     variant("optimisation_report", default=False, description="Generate optimisation reports.")
 
-    with when("@:access-esm0,access-esm2:"):
-        depends_on("netcdf-fortran@4.5.2:")
-        # Depend on virtual package "mpi".
-        depends_on("mpi")
-    with when("@access-esm1.5"):
-        depends_on("netcdf-fortran@4.5.1:")
-        # Depend on "openmpi".
-        depends_on("openmpi")
+    depends_on("netcdf-fortran@4.5.2:")
+    # Depend on virtual package "mpi".
+    depends_on("mpi")
 
     phases = ["edit", "build", "install"]
 
@@ -143,7 +140,7 @@ f90         = $(F90)
 f           = $(F90)
 """
 
-        config["gcc"] = f"""
+        config["gcc"] = """
 # Compiling and other commands
 MAKE        = make
 F90         = mpif90 -Wall -fallow-argument-mismatch
@@ -187,7 +184,7 @@ endif
         # Add support for the ifx compiler
         config["oneapi"] = config["intel"]
 
-        config["post"] = f"""
+        config["post"] = """
 f90FLAGS_1  = $(F90FLAGS_1)
 FFLAGS_1    = $(F90FLAGS_1)
 fFLAGS_1    = $(F90FLAGS_1)


### PR DESCRIPTION
This PR includes changes to allow us to switch to using `oasis3-mct` built from the `master` branch, rather than `access-esm1.5` branch, in ACCESS-ESM1.6.

A `version("stable", branch="master", preferred=True)` is introduced into the `oasis3-mct` SPR. Using this version in ACCESS-ESM1.6 does not change answers or performance (despite the associated change from [`-xCORE-AVX512` to `-axCORE-AVX2`](https://github.com/ACCESS-NRI/spack-packages/blob/f3d8c580af2898557c19c23fb0eb2260865f272a/packages/oasis3-mct/package.py#L223-L226)) - see [here](https://github.com/ACCESS-NRI/access-esm1.6-configs/pull/187#issuecomment-3226289134) and [here](https://github.com/ACCESS-NRI/access-esm1.6-configs/pull/187#issuecomment-3226651458).