### PR TITLE
Do not use -V in fflags: it fools the Spack compiler wrapper

### DIFF
--- a/packages/um7/package.py
+++ b/packages/um7/package.py
@@ -179,13 +179,13 @@ tool::cpp                                          cpp
 tool::cppflags
 tool::cppkeys                                      {CPPKEYS}
 tool::fc                                           mpif90
-tool::fflags                                       {FO}  -g   -traceback  {FDEBUG} -V -i8 -r8      -fp-model precise {FFLAGS}
-tool::fflags::control::coupling::dump_received     {FO} {FG} {FTRACEBACK} {FDEBUG}            -mp1 -fp-model strict  {FFLAGS}
-tool::fflags::control::coupling::dump_sent         {FO} {FG} {FTRACEBACK} {FDEBUG}            -mp1 -fp-model strict  {FFLAGS}
-tool::fflags::control::coupling::oasis3_atmos_init {FO} {FG} {FTRACEBACK} {FDEBUG}    -i4 -r8 -mp1 -fp-model strict  {FFLAGS}
-tool::fflags::control::top_level::atm_step         -O0   -g  {FTRACEBACK} {FDEBUG} -V -i8 -r8 -mp1 -fp-model strict  {FFLAGS}
-tool::fflags::control::top_level::set_atm_pointers -O0   -g   -traceback  {FDEBUG}    -i8 -r8      -fp-model strict -ftz -std95
-tool::fflags::control::top_level::u_model          -O0   -g  {FTRACEBACK} {FDEBUG} -V -i8 -r8 -mp1 -fp-model strict  {FFLAGS}
+tool::fflags                                       {FO}  -g   -traceback  {FDEBUG} -i8 -r8      -fp-model precise {FFLAGS}
+tool::fflags::control::coupling::dump_received     {FO} {FG} {FTRACEBACK} {FDEBUG}         -mp1 -fp-model strict  {FFLAGS}
+tool::fflags::control::coupling::dump_sent         {FO} {FG} {FTRACEBACK} {FDEBUG}         -mp1 -fp-model strict  {FFLAGS}
+tool::fflags::control::coupling::oasis3_atmos_init {FO} {FG} {FTRACEBACK} {FDEBUG} -i4 -r8 -mp1 -fp-model strict  {FFLAGS}
+tool::fflags::control::top_level::atm_step         -O0   -g  {FTRACEBACK} {FDEBUG} -i8 -r8 -mp1 -fp-model strict  {FFLAGS}
+tool::fflags::control::top_level::set_atm_pointers -O0   -g   -traceback  {FDEBUG} -i8 -r8      -fp-model strict -ftz -std95
+tool::fflags::control::top_level::u_model          -O0   -g  {FTRACEBACK} {FDEBUG} -i8 -r8 -mp1 -fp-model strict  {FFLAGS}
 tool::fpp                                          cpp
 tool::fppflags                                     -P -traditional
 tool::fppkeys                                      {CPPKEYS}


### PR DESCRIPTION
Remove the `-V` flags from the `fcm build` config within the UM7 Spack package recipe.

[At lines 277-289 of the Spack compiler wrapper](https://github.com/ACCESS-NRI/spack/blob/99f79c7cf1c97c55f5d1920679a4d5bb998b5dc3/lib/spack/env/cc#L277) there is a test to see if there are any arguments that represent a version check. In this case, [at lines 367-369](https://github.com/ACCESS-NRI/spack/blob/99f79c7cf1c97c55f5d1920679a4d5bb998b5dc3/lib/spack/env/cc#L367) the wrapper just executes the compiler command without adding arguments from `$SPACK_FFLAGS`.
```
# If any of the arguments below are present, then the mode is vcheck.
# In vcheck mode, nothing is added in terms of extra search paths or
# libraries.
if [ -z "$mode" ] || [ "$mode" = ld ]; then
    for arg in "$@"; do
        case $arg in
            -v|-V|--version|-dumpversion)
                mode=vcheck
                break
                ;;
        esac
    done
fi
[...]
if [ "$mode" = vcheck ]; then
    exec "${command}" "$@"
fi
```
Because lines 182, 186 and 188 of the FCM build config in [packages/um7/package.py](https://github.com/ACCESS-NRI/spack-packages/blob/main/packages/um7/package.py) contain `"-V"` flags, when `spack install` is run for `um7`, the Spack compiler wrapper is ignoring the value of `fflags`. The fix for now is simply to remove these flags, as they are not needed, and do not affect the code generated by the Intel Fortran compiler.

See also [the documentation for the Intel Fortran compiler `-logo` aka `-V` option](https://www.intel.com/content/www/us/en/docs/fortran-compiler/developer-guide-reference/2023-0/logo.html).
