### PR TITLE
Add ACCESS-ESM* token for spack-install-command-pat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,3 +140,5 @@ jobs:
       spack-packages-ref: ${{ needs.setup-ci.outputs.spack-packages-ref }}
       spack-config-ref: ${{ needs.setup-ci.outputs.spack-config-ref }}
       spack-ref: ${{ needs.setup-ci.outputs.spack-ref }}
+    secrets:
+      spack-install-command-pat: ${{ secrets.SPACK_INSTALL_COMMAND_PAT }}


### PR DESCRIPTION
See https://github.com/ACCESS-NRI/spack-packages/actions/runs/17287571815/job/49067594258?pr=315#step:13:4154 (from PR https://github.com/ACCESS-NRI/spack-packages/pull/315)

## Background

`ACCESS-ESM*`-related private components can't be built in `spack-packages` without a token. This PR adds a `secrets.SPACK_INSTALL_COMMAND_PAT` and ingests that via the workflow input `secrets.spack-install-command-pat`. 

## The PR

* Add `secrets.spack-install-command-pat`
