### PR TITLE
Copy `from spack.package import *` from upstream template

### DIFF
--- a/packages/access-fms/package.py
+++ b/packages/access-fms/package.py
@@ -5,7 +5,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.package import find_headers, find_libraries
+from spack.package import *
+
 
 # Based on upstream $spack/var/spack/repos/builtin/packages/fms/package.py
 class AccessFms(CMakePackage):

--- a/packages/access-generic-tracers/package.py
+++ b/packages/access-generic-tracers/package.py
@@ -3,7 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.package import find_libraries
+from spack.package import *
+
 
 class AccessGenericTracers(CMakePackage):
     """This is a fork of the NOAA-GFDL/ocean_BGC repo managed by NOAA-GFDL.

--- a/packages/access-issm/package.py
+++ b/packages/access-issm/package.py
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.package import BundlePackage, maintainers, version, depends_on
+from spack.package import *
 
 
 class AccessIssm(BundlePackage):

--- a/packages/access-mocsy/package.py
+++ b/packages/access-mocsy/package.py
@@ -5,8 +5,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.package import find_libraries, install, join_path, mkdirp
 from spack.build_systems import cmake, makefile
+from spack.package import *
 
 
 class AccessMocsy(CMakePackage, MakefilePackage):

--- a/packages/access-om3/package.py
+++ b/packages/access-om3/package.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.package import BundlePackage, version, depends_on
+from spack.package import *
 
 
 class AccessOm3(BundlePackage):
@@ -22,4 +22,4 @@ class AccessOm3(BundlePackage):
 
     version("latest")
 
-    depends_on("access3") 
+    depends_on("access3")

--- a/packages/access-ram3/package.py
+++ b/packages/access-ram3/package.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.package import BundlePackage, version, depends_on
+from spack.package import *
 
 
 class AccessRam3(BundlePackage):

--- a/packages/cice4/package.py
+++ b/packages/cice4/package.py
@@ -7,7 +7,8 @@
 
 # Based on packages/cice5/package.py and other sources noted below.
 
-from spack.package import install, join_path, mkdirp
+from spack.package import *
+
 
 # https://spack.readthedocs.io/en/latest/build_systems/makefilepackage.html
 class Cice4(MakefilePackage):

--- a/packages/cice5/package.py
+++ b/packages/cice5/package.py
@@ -5,7 +5,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.package import install, join_path, mkdirp
+from spack.package import *
+
 
 # https://spack.readthedocs.io/en/latest/build_systems/makefilepackage.html
 class Cice5(MakefilePackage):

--- a/packages/mom5/package.py
+++ b/packages/mom5/package.py
@@ -4,9 +4,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.package import install, join_path, mkdirp
 from spack.build_systems import cmake, makefile
 from spack.version.version_types import GitVersion, StandardVersion
+from spack.package import *
+
 
 class Mom5(CMakePackage, MakefilePackage):
     """MOM is a numerical ocean model based on the hydrostatic primitive equations."""


### PR DESCRIPTION
This is the first commit in the `api-v2` branch. Since it is compatible with Spack `v0.22` and `v1.0`, we might as well merge it into `main`.