### PR TITLE
`build-ci`: Fix incorrect manifest search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,10 @@ jobs:
               json_entry=$(printf '{"filepath": "%s", "template_value": "%s"}' "$manifest_path" "$template_value")
               json_entries+="${json_entry},"
             done
+            unset manifest_paths
           done
+
+          echo "$json_entries"
 
           # Remove the trailing comma and wrap in square brackets
           echo "matrix=[${json_entries%,}]" >> $GITHUB_OUTPUT


### PR DESCRIPTION
See run https://github.com/ACCESS-NRI/spack-packages/actions/runs/17404574596/job/49459311901?pr=317 (specifically, the incorrect `.github/build-ci/manifests/access-om3/gcc.spack.yaml.j2` for `access-ram3` - it should either be a `access-ram3` manifest or the default `.github/build-ci/manifests/gcc.spack.yaml.j2`). 

## The PR

* `unset` the `manifest_paths` variable between loops, as the `[ -z "$manifest_paths" ]` was picking up the previous loop iterations value. Whoops!
