### PR TITLE
`build-ci`: Only test `intel` for `cice4`

### DIFF
--- a/.github/build-ci/manifests/cice4/intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/cice4/intel.spack.yaml.j2
@@ -1,0 +1,12 @@
+spack:
+  specs:
+  # package is defined in the workflows inputs.spack-manifest-data-pairs
+  # And the intel_compilers are defined in the standard_definitions.json data file
+  - '{{ package }} %{{ intel_compiler }}'
+  packages:
+    all:
+      require:
+      - '%{{ intel_compiler }}'
+  concretizer:
+    unify: false
+  view: false


### PR DESCRIPTION
See https://github.com/ACCESS-NRI/spack-packages/actions/runs/17404574596/job/49459312049?pr=317
References #317

## Background

`cice4` doesn't build with `gcc`, so we will add only the `intel` manifest to the specific manifests to test for `cice4`
