### PR TITLE
Use default flag handler

### DIFF
--- a/packages/access-cice/package.py
+++ b/packages/access-cice/package.py
@@ -44,8 +44,6 @@ class AccessCice(CMakePackage):
 
     root_cmakelists_dir = "configuration/scripts/cmake"
 
-    flag_handler = build_system_flags
-
     def cmake_args(self):
         args = [
             self.define_from_variant("CICE_OPENMP", "openmp"),

--- a/packages/access-fms/package.py
+++ b/packages/access-fms/package.py
@@ -41,8 +41,6 @@ class AccessFms(CMakePackage):
     depends_on("netcdf-fortran")
     depends_on("mpi")
 
-    flag_handler = build_system_flags
-
     def url_for_version(self, version):
         return "https://github.com/ACCESS-NRI/FMS/tarball/{0}".format(version)
 

--- a/packages/access-generic-tracers/package.py
+++ b/packages/access-generic-tracers/package.py
@@ -53,8 +53,6 @@ class AccessGenericTracers(CMakePackage):
         depends_on("access-mocsy")
         depends_on("access-fms", when="+use_access_fms")
 
-    flag_handler = build_system_flags
-
     # TODO: We should try to remove this. The responsibility for including
     #       internal library dependencies for linking purposes should
     #       be in the source package's build system.

--- a/packages/access-mocsy/package.py
+++ b/packages/access-mocsy/package.py
@@ -53,8 +53,6 @@ class AccessMocsy(CMakePackage, MakefilePackage):
 
     depends_on("mpi")
 
-    flag_handler = build_system_flags
-
 
 class CMakeBuilder(cmake.CMakeBuilder):
 

--- a/packages/access-mom6/package.py
+++ b/packages/access-mom6/package.py
@@ -45,7 +45,6 @@ class AccessMom6(CMakePackage):
     depends_on("fms ~openmp", when="~openmp")
     depends_on("access-generic-tracers ~use_access_fms", when="@2025.02.001:")
 
-    flag_handler = build_system_flags
 
     def cmake_args(self):
         args = [

--- a/packages/access-test-component/package.py
+++ b/packages/access-test-component/package.py
@@ -28,7 +28,5 @@ class AccessTestComponent(CMakePackage):
 
     root_cmakelists_dir = "stub"
 
-    flag_handler = build_system_flags
-
     def url_for_version(self, version):
         return f"https://github.com/{self.githubrepo}/tarball/{version}"

--- a/packages/access-ww3/package.py
+++ b/packages/access-ww3/package.py
@@ -31,8 +31,6 @@ class AccessWw3(CMakePackage):
     depends_on("mpi")
     depends_on("netcdf-fortran@4.6.0:")
 
-    flag_handler = build_system_flags
-
     def cmake_args(self):
         args = [
             self.define_from_variant("WW3_OPENMP", "openmp"),

--- a/packages/access3-share/package.py
+++ b/packages/access3-share/package.py
@@ -38,8 +38,6 @@ class Access3Share(CMakePackage):
                 "cflags='-qno-opt-dynamic-align -fp-model precise -std=gnu99'"),
                 when="%intel")  # consistency with access-om3-nuopc builds, e.g. https://github.com/ACCESS-NRI/spack-packages/blob/e2bdb46e56af8ac14183e7ed25da9235486c973a/packages/access-om3-nuopc/package.py#L65
 
-    flag_handler = build_system_flags
-
     def cmake_args(self):
         args = [
             self.define("ACCESS3_LIB_INSTALL", True),

--- a/packages/access3/package.py
+++ b/packages/access3/package.py
@@ -65,8 +65,6 @@ class Access3(CMakePackage):
         if "WW3" in conf:
             depends_on("access-ww3@2025.03.0: +access3", when=f"configurations={conf}")
 
-    flag_handler = build_system_flags
-
     def cmake_args(self):
         # make configurations a cmake argument
         buildConf = ";".join(self.spec.variants["configurations"].value)

--- a/packages/cable/package.py
+++ b/packages/cable/package.py
@@ -46,8 +46,6 @@ class Cable(CMakePackage):
     depends_on("netcdf-fortran@4.5.2:")
     depends_on("mpi", when="+mpi")
 
-    flag_handler = build_system_flags
-
     def cmake_args(self):
         args = []
         args.append(self.define_from_variant("CABLE_MPI", "mpi"))

--- a/packages/datetime-fortran/package.py
+++ b/packages/datetime-fortran/package.py
@@ -41,8 +41,6 @@ class DatetimeFortran(AutotoolsPackage):
 
     patch("0001-Enable-deterministic-builds-using-D-flag-for-ar.patch", when="@1.7.0")
 
-    flag_handler = build_system_flags
-
     def url_for_version(self, version):
         return "https://github.com/wavebitscientific/datetime-fortran/releases/download/v{0}/datetime-fortran-{0}.tar.gz".format(version)
 

--- a/packages/fiat/package.py
+++ b/packages/fiat/package.py
@@ -45,8 +45,6 @@ class Fiat(CMakePackage):
     patch("intel_warnings_v110.patch", when="@0:1.1.0")
     patch("intel_warnings_v120.patch", when="@1.2.0:")
 
-    flag_handler = build_system_flags
-
     def cmake_args(self):
         args = [
             self.define_from_variant("ENABLE_OMP", "openmp"),

--- a/packages/fortranxml/package.py
+++ b/packages/fortranxml/package.py
@@ -19,7 +19,7 @@ class Fortranxml(AutotoolsPackage):
 
     version("4.1.2", sha256="1938725be45b8be5387a51fa0b25ee78ffee87ca8a497b82545ab870f33f8b88")
 
-    flag_handler = build_system_flags
+    flag_handler = AutotoolsPackage.build_system_flags
 
     def url_for_version(self, version):
         return "https://github.com/andreww/fox/tarball/{0}".format(version)

--- a/packages/fortranxml/package.py
+++ b/packages/fortranxml/package.py
@@ -19,8 +19,6 @@ class Fortranxml(AutotoolsPackage):
 
     version("4.1.2", sha256="1938725be45b8be5387a51fa0b25ee78ffee87ca8a497b82545ab870f33f8b88")
 
-    flag_handler = AutotoolsPackage.build_system_flags
-
     def url_for_version(self, version):
         return "https://github.com/andreww/fox/tarball/{0}".format(version)
 

--- a/packages/fre-nctools/package.py
+++ b/packages/fre-nctools/package.py
@@ -47,8 +47,6 @@ class FreNctools(AutotoolsPackage):
     depends_on("mpi", when="+mpi")
     depends_on("nco", when="@2024.05:")
 
-    flag_handler = build_system_flags
-
     def configure_args(self):
         spec = self.spec
         args = []

--- a/packages/issm/package.py
+++ b/packages/issm/package.py
@@ -95,8 +95,6 @@ class Issm(AutotoolsPackage):
     depends_on("python@3.9.2:", when="+wrappers", type=("build", "run"))
     depends_on("py-numpy", when="+wrappers", type=("build", "run"))
 
-    flag_handler = build_system_flags
-
     # GCC 14 breaks on several C++17 constructs used in ISSM
     conflicts("%gcc@14:", msg="ISSM cannot be built with GCC versions above 13")
 

--- a/packages/libaccessom2/package.py
+++ b/packages/libaccessom2/package.py
@@ -35,8 +35,6 @@ class Libaccessom2(CMakePackage):
     depends_on("json-fortran")
     depends_on("netcdf-fortran@4.5.2:")
 
-    flag_handler = build_system_flags
-
     def url_for_version(self, version):
         return "https://github.com/ACCESS-NRI/libaccessom2/tarball/{0}".format(version)
 


### PR DESCRIPTION
The issues seen with the CMake build system (https://github.com/ACCESS-NRI/spack-packages/issues/268) have demonstrated that reverting back to the default `flag_handler` results in a more predicable user experience.

Furthermore, since Spack upstream are planning to save the compiler wrapper output alongside the build logs (https://github.com/spack/spack/issues/50972), the original need to override the default `flag_handler` is less relevant.

#### Problem
The Spack compiler flag overrides, e.g. `-g -O1`, are overridden by CMake defaults, e.g. `-O3`:
```
[cc] /opt/release/linux-rocky8-x86_64/gcc-8.5.0/intel-oneapi-compilers-2023.2.4-hxxociow5cqbgxig7jtdtiwpg6tst7bs/compiler/2023.2.4/linux/bin/intel64/ifort -g -O1 -O3 -c /tmp/root/spack-stage/spack-stage-access-test-component-main-7esg4kddhcj3nogz6y4x7zohzdpjxvuw/spack-src/stub/src/hello_world.f90 -o CMakeFiles/hello_world.exe.dir/src/hello_world.f90.o -I/opt/release/linux-rocky8-x86_64/intel-2021.10.0/openmpi-4.1.5-33u4t3p57v6dlsw3hvgbf274nfs65kkm/include -I/opt/release/linux-rocky8-x86_64/intel-2021.10.0/openmpi-4.1.5-33u4t3p57v6dlsw3hvgbf274nfs65kkm/lib
```
```
[cc] /opt/release/linux-rocky8-x86_64/gcc-8.5.0/intel-oneapi-compilers-2023.2.4-hxxociow5cqbgxig7jtdtiwpg6tst7bs/compiler/2023.2.4/linux/bin/intel64/ifort -march=pentium4 -mtune=generic -I/opt/release/linux-rocky8-x86_64/intel-2021.10.0/openmpi-4.1.5-33u4t3p57v6dlsw3hvgbf274nfs65kkm/include -I/opt/release/linux-rocky8-x86_64/intel-2021.10.0/openmpi-4.1.5-33u4t3p57v6dlsw3hvgbf274nfs65kkm/lib -I/opt/release/linux-rocky8-x86_64/intel-2021.10.0/openmpi-4.1.5-33u4t3p57v6dlsw3hvgbf274nfs65kkm/include -I/opt/release/linux-rocky8-x86_64/intel-2021.10.0/pmix-4.2.2-dw3g7lawospr4js7jime5s6bfdxppibz/include -I/opt/release/linux-rocky8-x86_64/intel-2021.10.0/numactl-2.0.14-t3rlsc7akk2t3y4hgrojeb3cmnkmras4/include -I/opt/release/linux-rocky8-x86_64/intel-2021.10.0/libevent-2.1.12-kevlg4ejyin3bta5n4pbgj7tbha6te6i/include -I/opt/release/linux-rocky8-x86_64/intel-2021.10.0/hwloc-2.9.1-ttmbevukplm62qsgonna4qsriaxu6n56/include -I/opt/release/linux-rocky8-x86_64/intel-2021.10.0/libxml2-2.10.3-27uhbc2uhsnx4efljnaqpz2yk5srpino/include/libxml2 -I/opt/release/linux-rocky8-x86_64/intel-2021.10.0/libxml2-2.10.3-27uhbc2uhsnx4efljnaqpz2yk5srpino/include -I/opt/release/linux-rocky8-x86_64/intel-2021.10.0/xz-5.4.6-fwcrp5ubrritrufvzf3xagz6zpjvme2m/include -I/opt/release/linux-rocky8-x86_64/intel-2021.10.0/libpciaccess-0.17-toioathrvka5yv73xrj5yy6hhbdifqdx/include -I/opt/release/linux-rocky8-x86_64/intel-2021.10.0/ncurses-6.5-qxjalh4zjhgs54mavnrcfhjv32nzmzqq/include -I/opt/release/linux-rocky8-x86_64/intel-2021.10.0/openssl-3.3.0-eg3yw5oy77irndzexrmlhq2mwnw2gua7/include -I/opt/release/linux-rocky8-x86_64/intel-2021.10.0/zlib-ng-2.1.6-wa2x7rho3km6qpiki56dpjlpsce4c5n6/include -I/opt/release/linux-rocky8-x86_64/intel-2021.10.0/libiconv-1.17-55ipnyeeqcpbfgaqfanu36viaqqni3sx/include -g -O1 -O3 -c /tmp/root/spack-stage/spack-stage-access-test-component-main-7esg4kddhcj3nogz6y4x7zohzdpjxvuw/spack-src/stub/src/hello_world.f90 -o CMakeFiles/hello_world.exe.dir/src/hello_world.f90.o
```

```
# This is a Spack Environment file.
#
# It describes a set of packages to be installed, along with
# configuration settings.
spack:
  specs:
    - access-test@git.2025.09.000
  packages:
    access-test-component:
      require:
        - '@main'
        - 'cflags="-O1 -g"'
        - 'cxxflags="-O1 -g"'
        - 'fflags="-O1 -g"'
    openmpi:
      require:
        - '@4.1.5'
    gcc-runtime:
      require:
        - '%gcc'
    all:
      require:
        - '%intel@2021.10.0'
        - 'target=x86_64'
  view: true
  concretizer:
    unify: true
```