### PR TITLE
Add missing `%` to `issm` `build-ci`

### DIFF
--- a/.github/build-ci/manifests/issm/spack.yaml.j2
+++ b/.github/build-ci/manifests/issm/spack.yaml.j2
@@ -5,7 +5,7 @@ spack:
     - ['issm']
     - ['+ad', '~ad']
     - ['+wrappers']
-    - ['{{ gcc_compiler }}']
+    - ['%{{ gcc_compiler }}']
   concretizer:
     unify: false
   view: false


### PR DESCRIPTION
See https://github.com/ACCESS-NRI/spack-packages/actions/runs/17784233559/job/50553838115?pr=321#step:13:26

## Background

I'd mistakenly forgot to add the `%` compiler sigil to the `issm` manifest in the repo. This PR adds it. 
