### PR TITLE
Add options for building libraries for CM3

### DIFF
--- a/packages/access-cice/package.py
+++ b/packages/access-cice/package.py
@@ -40,7 +40,7 @@ class AccessCice(CMakePackage):
             default="none",
             values=("none", "nuopc/cmeps", "access/cmeps", "standalone/cice"),
             description="CICE driver path"
-            )
+    )
 
     depends_on("access3-share", when="+access3") 
     depends_on("cmake@3.18:", type="build")
@@ -61,5 +61,6 @@ class AccessCice(CMakePackage):
 
         if self.spec.variants["driver"].value != "none":
             args.append(self.define_from_variant("CICE_DRIVER", "driver"))
+      # if driver="none" respect default set through CMake
 
         return args

--- a/packages/access-cice/package.py
+++ b/packages/access-cice/package.py
@@ -37,8 +37,8 @@ class AccessCice(CMakePackage):
     )
 
     variant("driver",
-            default="access/cmeps",
-            values=("nuopc/cmeps", "access/cmeps", "standalone/cice"),
+            default="none",
+            values=("none", "nuopc/cmeps", "access/cmeps", "standalone/cice"),
             description="CICE driver path"
             )
 
@@ -57,7 +57,9 @@ class AccessCice(CMakePackage):
             self.define_from_variant("CICE_OPENMP", "openmp"),
             self.define_from_variant("CICE_IO", "io_type"),
             self.define_from_variant("CICE_ACCESS3", "access3"),
-            self.define_from_variant("CICE_DRIVER", "driver")
         ]
+
+        if self.spec.variants["driver"].value != "none":
+            args.append(self.define_from_variant("CICE_DRIVER", "driver"))
 
         return args

--- a/packages/access-cice/package.py
+++ b/packages/access-cice/package.py
@@ -61,6 +61,6 @@ class AccessCice(CMakePackage):
 
         if self.spec.variants["driver"].value != "none":
             args.append(self.define_from_variant("CICE_DRIVER", "driver"))
-      # if driver="none" respect default set through CMake
+        # if driver="none" respect default set through CMake
 
         return args

--- a/packages/access-cice/package.py
+++ b/packages/access-cice/package.py
@@ -36,6 +36,12 @@ class AccessCice(CMakePackage):
         description="CICE IO Method"
     )
 
+    variant("driver",
+            default="none",
+            values=("nuopc/cmeps", "access/cmeps", "standalone/cice"),
+            description="CICE driver path"
+            )
+
     depends_on("access3-share", when="+access3") 
     depends_on("cmake@3.18:", type="build")
     depends_on("mpi")
@@ -51,6 +57,7 @@ class AccessCice(CMakePackage):
             self.define_from_variant("CICE_OPENMP", "openmp"),
             self.define_from_variant("CICE_IO", "io_type"),
             self.define_from_variant("CICE_ACCESS3", "access3"),
+            self.define_from_variant("CICE_DRIVER", "driver")
         ]
 
         return args

--- a/packages/access-cice/package.py
+++ b/packages/access-cice/package.py
@@ -37,7 +37,7 @@ class AccessCice(CMakePackage):
     )
 
     variant("driver",
-            default="none",
+            default="access/cmeps",
             values=("nuopc/cmeps", "access/cmeps", "standalone/cice"),
             description="CICE driver path"
             )

--- a/packages/access3/package.py
+++ b/packages/access3/package.py
@@ -13,7 +13,6 @@ KNOWN_CONF = (
     "MOM6-CICE6",
     "CICE6-WW3",
     "MOM6-CICE6-WW3",
-    "MOM6-CICE6-UM13",
 )
 
 class Access3(CMakePackage):
@@ -65,8 +64,6 @@ class Access3(CMakePackage):
             depends_on("access-mom6@2025.02.000: +access3", when=f"configurations={conf}")
         if "WW3" in conf:
             depends_on("access-ww3@2025.03.0: +access3", when=f"configurations={conf}")
-        if "UM13" in conf:
-            depends_on("gcom@8.0", when=f"configurations={conf}")
 
     flag_handler = build_system_flags
 

--- a/packages/access3/package.py
+++ b/packages/access3/package.py
@@ -13,6 +13,7 @@ KNOWN_CONF = (
     "MOM6-CICE6",
     "CICE6-WW3",
     "MOM6-CICE6-WW3",
+    "MOM6-CICE6-UM13",
 )
 
 class Access3(CMakePackage):
@@ -64,6 +65,8 @@ class Access3(CMakePackage):
             depends_on("access-mom6@2025.02.000: +access3", when=f"configurations={conf}")
         if "WW3" in conf:
             depends_on("access-ww3@2025.03.0: +access3", when=f"configurations={conf}")
+        if "UM13" in conf:
+            depends_on("gcom@8.0", when=f"configurations={conf}")
 
     flag_handler = build_system_flags
 


### PR DESCRIPTION
Closes #324 

This PR adds a `driver` variant to the `access-cice` spack package. This allows a custom relative path to be set for the [`CICE_DRIVER` option](https://github.com/ACCESS-NRI/CICE/blob/725ca300c65647dade425c6d037fe1d6d335e853/configuration/scripts/cmake/CMakeLists.txt#L35-L43) in the CICE CMake build.


It also adds a `MOM6-CICE6-UM13` build configuration to the `access3` package, which adds `gcom` as a dependency when active, as suggested [here](https://github.com/ACCESS-NRI/dev_coupling/issues/56#issuecomment-2840460649). If we decide to it this way, this build configuration will also need to be added to the [known configurations](https://github.com/ACCESS-NRI/access3-share/blob/e89f37b504eeebba8f951e90f88078a479216104/cmake/Access3BinInstall.cmake#L10) in the cmake build 


