### PR TITLE
access3-share: use defined namespace with import

### DIFF
--- a/packages/access3-share/package.py
+++ b/packages/access3-share/package.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from .access3 import ACCESS3_VERSIONS
+from spack.pkg.access.nri.access3 import ACCESS3_VERSIONS
 
 class Access3Share(CMakePackage):
     """Shared coupler/mediator libraries used by the ACCESS version 3 climate


### PR DESCRIPTION
This PR makes a change that is supported by Spack v0.22. For Spack v1.0, we need to follow https://github.com/ACCESS-NRI/spack-packages/issues/334 .