### PR TITLE
Add py-tools variant and set $ISSM_DIR Environment Variable

### DIFF
--- a/packages/issm/package.py
+++ b/packages/issm/package.py
@@ -7,6 +7,7 @@
 
 from spack.package import *
 import zipfile
+import os
 
 
 class Issm(AutotoolsPackage):
@@ -231,14 +232,23 @@ class Issm(AutotoolsPackage):
             # Exclude contrib directory which contains working files
             exclude_dirs = {'contrib'}
 
-            # Find all .py files recursively
-            py_files = find(py_src, "*.py")
+            # Empty list to hold paths of .py files
+            py_files = []
 
-            # Exclude files in the specified directories
-            py_files = [
-                f for f in py_files
-                if not any(f"/{excl}/" in f for excl in exclude_dirs)
-            ]
+            # Walk through the directory tree
+            for root, dirs, files in os.walk(py_src):
+
+                # Split root into path parts (to allow direct exclusion of exclude_dirs)
+                parts = os.path.normpath(root).split(os.sep)
+
+                # Skip excluded directories
+                if any(excl in parts for excl in exclude_dirs):
+                    continue
+
+                # Iterate over files in the current directory and collect .py files
+                for file in files:
+                    if file.endswith('.py'):
+                        py_files.append(join_path(root, file))
 
             # Create the ZIP archive
             with zipfile.ZipFile(py_dst, "w", zipfile.ZIP_DEFLATED) as zf:


### PR DESCRIPTION
This PR adds the following functionality:
- New `py-tools` variant to install Python function files to `<prexix>/python-tools/`. These files are necessary to A) access the wrappers that are included in `<prefix>/lib/` and B) to conduct various pre- and post-processing of ISSM models. Note: Python files are stored in various subdirectories (e.g. `src/m/mesh`, `src/m/mask`, `src/m/solve`) in the ISSM directory. Here, we flatten this structure to just save all Python files in one directory (`<prefix>/python-tools/`) as the subdirectory structure serves no functional purpose.

- Export `$ISSM_DIR` environment variable. This is required by various Python wrappers to obtain information about the run environment.

This PR addresses Issue #333.

Functionality was tested in https://github.com/ACCESS-NRI/ACCESS-ISSM/pull/25
