### PR TITLE
Add `spack-repo-index.yaml`

### DIFF
--- a/spack-repo-index.yaml
+++ b/spack-repo-index.yaml
@@ -1,0 +1,3 @@
+repo_index:
+  paths:
+  - spack_repo/access/nri


### PR DESCRIPTION
References ACCESS-NRI/spack-config#81

## Background

This file is used by `spack >= v1` to index collections of spack-packages within a single repository. We don't use this feature in our instances of spack (having a single `spack_repo/access/nri` one) but it is required to make the `spack repo update` command work, which will be used going forward in both `build-ci` and `build-cd`. 

## The PR

* Add `spack-repo-index.yaml` that points to the `spack_repos/access/nri` collection of packages

## Testing

Tested locally in a docker image using `spack-config` with branch `access-spack-packages-as-git-repo` branch (see ACCESS-NRI/spack-config#82):

```bash
spack repo list  # Has our ACCESS-NRI/spack-packages repo successfully linked (the [+])
spack repo update access_spack_packages  # And we can update our repository via this command, also with --commit/--tag/--branch flags
```