### PR TITLE
Changes required to use CABLE as a library for ESM1.6

### DIFF
--- a/.github/build-ci/manifests/um7/intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/um7/intel.spack.yaml.j2
@@ -1,0 +1,13 @@
+# This manifest is used by default for packages without a specific manifest under .github/build-ci/manifests/PACKAGE/*.j2
+spack:
+  specs:
+  # package is defined in the workflows inputs.spack-manifest-data-pairs
+  # And the intel_compilers are defined in the standard_definitions.json data file
+  - '{{ package }} %{{ intel_compiler }}'
+  packages:
+    all:
+      require:
+      - '%{{ intel_compiler }}'
+  concretizer:
+    unify: false
+  view: false

--- a/packages/cable/package.py
+++ b/packages/cable/package.py
@@ -35,7 +35,7 @@ class Cable(CMakePackage):
         default="none",
         values=(
             "none",
-            "esm1.6"
+            "ESM1.6"
         ),
         description="Build CABLE science library object.",
     )

--- a/packages/cable/package.py
+++ b/packages/cable/package.py
@@ -34,7 +34,7 @@ class Cable(CMakePackage):
         "library",
         default="none",
         values=(
-            conditional("ESM1.6", when="@access-esm1.6")
+            "ESM1.6"
         ),
         description="Build CABLE science library object.",
     )

--- a/packages/cable/package.py
+++ b/packages/cable/package.py
@@ -17,7 +17,7 @@ class Cable(CMakePackage):
     homepage = "https://github.com/CABLE-LSM/CABLE"
     git = "https://github.com/CABLE-LSM/CABLE.git"
 
-    maintainers("SeanBryan51")
+    maintainers("SeanBryan51", "Whyborn")
 
     version("main", branch="main")
 

--- a/packages/cable/package.py
+++ b/packages/cable/package.py
@@ -33,6 +33,9 @@ class Cable(CMakePackage):
     variant(
         "library",
         default=False,
+        values=(
+            conditional("ESM1.6", when="@access-esm1.6")
+        ),
         description="Build CABLE science library object.",
     )
 
@@ -49,5 +52,6 @@ class Cable(CMakePackage):
     def cmake_args(self):
         args = []
         args.append(self.define_from_variant("CABLE_MPI", "mpi"))
-        args.append(self.define_from_variant("CABLE_LIBRARY", "library"))
+        args.append(self.define("CABLE_LIBRARY", self.spec.variants["library"].value != "none"))
+        args.append(self.define_from_variant("CABLE_LIBRARY_TARGET", "library"))
         return args

--- a/packages/cable/package.py
+++ b/packages/cable/package.py
@@ -32,7 +32,7 @@ class Cable(CMakePackage):
 
     variant(
         "library",
-        default=False,
+        default="none",
         values=(
             conditional("ESM1.6", when="@access-esm1.6")
         ),

--- a/packages/cable/package.py
+++ b/packages/cable/package.py
@@ -34,7 +34,8 @@ class Cable(CMakePackage):
         "library",
         default="none",
         values=(
-            "ESM1.6"
+            "none",
+            "esm1.6"
         ),
         description="Build CABLE science library object.",
     )

--- a/packages/cable/package.py
+++ b/packages/cable/package.py
@@ -35,7 +35,7 @@ class Cable(CMakePackage):
         default="none",
         values=(
             "none",
-            "ESM1.6"
+            "access-esm1.6"
         ),
         description="Build CABLE science library object.",
     )

--- a/packages/um7/package.py
+++ b/packages/um7/package.py
@@ -42,7 +42,7 @@ class Um7(Package):
             values=("high", "debug"), multi=False)
 
     with when("@access-esm1.6"):
-        depends_on("cable library=ESM1.6", type=("build", "link"))
+        depends_on("cable library='access-esm1.6'", type=("build", "link"))
 
     phases = ["edit", "build", "install"]
 
@@ -190,6 +190,7 @@ excl_dep                                           USE::POP_TYPES
 excl_dep                                           USE::cable_runtime_opts_mod
 excl_dep                                           USE::landuse_mod
             """
+
         config = f"""
 # ------------------------------------------------------------------------------
 # File header

--- a/packages/um7/package.py
+++ b/packages/um7/package.py
@@ -23,7 +23,7 @@ class Um7(Package):
     version("access-esm1.6", branch="dev-access-esm1.6", preferred=True)
     version("access-esm1.5", branch="access-esm1.5")
 
-    maintainers("penguian")
+    maintainers("penguian", "Whyborn")
 
     depends_on("fcm", type="build")
     depends_on("dummygrib", type=("build", "link"))

--- a/packages/um7/package.py
+++ b/packages/um7/package.py
@@ -42,7 +42,7 @@ class Um7(Package):
             values=("high", "debug"), multi=False)
 
     with when("@access-esm1.6"):
-        depends_on("cable", type=("build", "link"))
+        depends_on("cable library=ESM1.6", type=("build", "link"))
 
     phases = ["edit", "build", "install"]
 

--- a/packages/um7/package.py
+++ b/packages/um7/package.py
@@ -143,6 +143,14 @@ class Um7(Package):
             FARCH = "-xCORE-AVX512"
             FOBLANK = ""
 
+        # FCM tries to find all instances of USE and include them as
+        # source code, except things explicitly excluded by excl_deps.
+        # This means when using CABLE as a library, everything USEd
+        # by the coupled infrastructure, which still lives in UM7,
+        # must be explicitly included. Leave the default of an empty
+        # string for older versions of UM7 which include CABLE as
+        # source code.
+        CABLE_excl_deps = ""
         with when("@access-esm1.6"):
             CABLE_excl_deps = """
 excl_dep                                           USE::cable_def_types_mod

--- a/packages/um7/package.py
+++ b/packages/um7/package.py
@@ -41,6 +41,9 @@ class Um7(Package):
     variant("optim", default="high", description="Optimization level",
             values=("high", "debug"), multi=False)
 
+    with when("@access-esm1.6"):
+        depends_on("cable", type=("build", "link"))
+
     phases = ["edit", "build", "install"]
 
 
@@ -53,6 +56,8 @@ class Um7(Package):
                 join_path(self.spec["oasis3-mct"].prefix.include, subdir)
                 for subdir in ["psmile.MPI1", "mct"]]
         ideps = ["gcom4", "netcdf-fortran"]
+        with when("@access-esm1.6"):
+            ideps.append("cable")
         incs = [self.spec[d].prefix.include for d in ideps] + oasis3_incs
         for ipath in incs:
             env.prepend_path("CPATH", ipath)
@@ -97,6 +102,8 @@ class Um7(Package):
         """
 
         ldeps = ["oasis3-mct", "netcdf-fortran", "dummygrib"]
+        with when("@access-esm1.6"):
+            ldeps.append("cable")
         libs = " ".join([self._get_linker_args(spec, d) for d in ldeps] + ["-lgcom"])
 
         opt_value = spec.variants["optim"].value
@@ -136,6 +143,45 @@ class Um7(Package):
             FARCH = "-xCORE-AVX512"
             FOBLANK = ""
 
+        with when("@access-esm1.6"):
+            CABLE_excl_deps = """
+excl_dep                                           USE::cable_def_types_mod
+excl_dep                                           USE::cbl_masks_mod
+excl_dep                                           USE::cable_other_constants_mod
+excl_dep                                           USE::cable_math_constants_mod
+excl_dep                                           USE::cable_phys_constants_mod
+excl_dep                                           USE::cable_soil_params_mod
+excl_dep                                           USE::cable_common_module
+excl_dep                                           USE::cbl_init_radiation_module
+excl_dep                                           USE::grid_constants_mod_cbl
+excl_dep                                           USE::cable_surface_types_mod
+excl_dep                                           USE::cable_soil_type_mod
+excl_dep                                           USE::cable_veg_type_mod
+excl_dep                                           USE::cable_pft_params_mod
+excl_dep                                           USE::cbl_albedo_mod
+excl_dep                                           USE::cbl_soil_snow_main_module
+excl_dep                                           USE::cable_soil_snow_type_mod
+excl_dep                                           USE::cbl_lai_canopy_height_mod
+excl_dep                                           USE::cable_carbon_module
+excl_dep                                           USE::snow_aging_mod
+excl_dep                                           USE::cable_roughness_module
+excl_dep                                           USE::cable_air_module
+excl_dep                                           USE::cable_canopy_module
+excl_dep                                           USE::cable_canopy_type_mod
+excl_dep                                           USE::casadimension
+excl_dep                                           USE::casa_inout_module
+excl_dep                                           USE::casa_readbiome_module
+excl_dep                                           USE::cable_init_wetfac_mod
+excl_dep                                           USE::casavariable
+excl_dep                                           USE::casaparm
+excl_dep                                           USE::phenvariable
+excl_dep                                           USE::feedback_mod
+excl_dep                                           USE::bgcdriver_mod
+excl_dep                                           USE::sumcflux_mod
+excl_dep                                           USE::POP_TYPES
+excl_dep                                           USE::cable_runtime_opts_mod
+excl_dep                                           USE::landuse_mod
+            """
         config = f"""
 # ------------------------------------------------------------------------------
 # File header
@@ -167,6 +213,7 @@ excl_dep                                           USE::mod_prism_grids_writing
 excl_dep                                           USE::mod_prism_def_partition_proto
 excl_dep                                           USE::mod_prism_put_proto
 excl_dep                                           USE::mod_prism_get_proto
+{CABLE_excl_deps}
 excl_dep::script                                   EXE
 exe_dep                                            portio2a.o pio_data_conv.o pio_io_timer.o
 exe_name::flumeMain                                {EXE_NAME}


### PR DESCRIPTION
Associated PR in ESM1.6 that shows bitwise compatibility with non-library build: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/156
UM PR that removes the CABLE code: https://github.com/ACCESS-NRI/UM7/pull/176

The implementation in the UM7 spack package feels quite clunky but I couldn't think of a better way to do it. Happy to hear suggestions on how to improve it.