### PR TITLE
CI: Underscore to hyphen fix, small readability changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       DEFAULT_SPACK_REF: 'releases/v1.0'
       DEFAULT_SPACK_CONFIG_REF: 'main'
       DEFAULT_SPACK_PACKAGES_REF: ${{ github.event.pull_request.head.sha }}
+      PACKAGES_ROOT_DIR: spack_repo/access/nri/packages
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       spack-packages-ref: ${{ steps.set-refs.outputs.spack-packages-ref }}
@@ -45,10 +46,10 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c  # v46.0.5
         with:
-          # We only care about the directory names under packages/ - since they are also the package names
+          # We only care about the directory names under the env.PACKAGES_ROOT_DIR - since they are also the package names
           # and we want to find changes to the package.py files in those directories
           dir_names: true
-          path: ./spack_repo/access/nri/packages
+          path: ./${{ env.PACKAGES_ROOT_DIR }}
           files: '*/package.py'
 
       - name: Dispatch - Get packages
@@ -57,7 +58,7 @@ jobs:
         # Either get all packages defined (all subfolders under packages/) or use the input
         run: |
           if [[ "${{ inputs.packages-to-test }}" == "ALL" ]]; then
-            pkgs=$(find spack_repo/access/nri/packages/ -mindepth 1 -maxdepth 1 -type d -printf '%P ')
+            pkgs=$(find ${{ env.PACKAGES_ROOT_DIR }}/ -mindepth 1 -maxdepth 1 -type d -printf '%P ')
           else
             pkgs="${{ inputs.packages-to-test }}"
           fi
@@ -66,7 +67,7 @@ jobs:
           # Validate that all packages exist
           error=false
           for pkg in $pkgs; do
-            if [ ! -f "packages/$pkg/package.py" ]; then
+            if [ ! -f "${{ env.PACKAGES_ROOT_DIR }}/$pkg/package.py" ]; then
               echo "::error::packages/$pkg/package.py does not exist. Check spelling or if the package is defined."
               error=true
             fi


### PR DESCRIPTION
## Background

Currently in https://github.com/ACCESS-NRI/spack-packages/pull/332, packages are being tested for compliance for changes in `spack v1`. 
One of those changes is that the directory structure has changed, and package directories should have `_` rather than `-` (so they are valid python modules). They are then converted back into their `-`-style packages for `spack`.

However, this means that the CI has been failing, because it has been using the `_` package directories as package names, which doesn't work.

I've also added some readability fixes to the matrix, so the name of the package comes first, rather than the filepath. 

## The PR

* Replace `_` from package directory name with `-` for package names in `template_value`
* Swap `filepath` and `template_value` in matrix, so the package name is more visible in the CI on the web
* Also update paths to `api-v2` format (I had missed the `workflow_dispatch` case!)
