### PR TITLE
Update ISSM package

### DIFF
--- a/packages/issm/package.py
+++ b/packages/issm/package.py
@@ -69,15 +69,13 @@ class Issm(AutotoolsPackage):
     # --------------------------------------------------------------------
     # Dependencies
     # --------------------------------------------------------------------
-
-    # Build-time & runtime dependencies
-    # --------------------------------------------------------------------
+    # Build-time tools
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
     depends_on("m4", type="build")
 
-    # Runtime MPI dependency
+    # Core build + runtime deps
     depends_on("mpi")
 
     # Conditional dependencies


### PR DESCRIPTION
This PR contains the following main updates:
- Add `access-release` as preferred branch on [ACCESS-NRI ISSM fork](https://github.com/ACCESS-NRI/ISSM/tree/access-release) to handle official releases.
- Fix `+ad` variant by adjusting conditional syntax for variants.
- Remove Python version dependency here as this is specified in the `spack.yaml`.