### PR TITLE
oasis3-mct: add upstream version OASIS3-MCT_5.2

### DIFF
--- a/packages/oasis3-mct/package.py
+++ b/packages/oasis3-mct/package.py
@@ -23,6 +23,11 @@ class Oasis3Mct(MakefilePackage):
         branch="OASIS3-MCT_5.0",
         git="https://gitlab.com/cerfacs/oasis3-mct.git",
     )
+    version(
+        "OASIS3-MCT_5.2",
+        tag="OASIS3-MCT_5.2",
+        git="https://gitlab.com/cerfacs/oasis3-mct.git",
+    )
     # TODO: Remove the "access-om2" once it is no longer being used anywhere
     version("access-om2", branch="master")
     version("access-esm1.5", branch="access-esm1.5")
@@ -59,7 +64,7 @@ class Oasis3Mct(MakefilePackage):
 
     # TODO: Remove this function when it is no longer required
     def url_for_version(self, version):
-        if self.spec.satisfies("@upstream"):
+        if self.spec.satisfies("@upstream,OASIS3-MCT_5.2"):
             raise ValueError("url_for_version() called for version @upstream")
 
         return "https://github.com/ACCESS-NRI/oasis3-mct/tarball/{0}".format(version)
@@ -67,7 +72,7 @@ class Oasis3Mct(MakefilePackage):
     def __create_pkgconfig(self, spec, prefix):
 
         oasis_version = "2.0"
-        if self.spec.satisfies("@upstream"):
+        if self.spec.satisfies("@upstream,OASIS3-MCT_5.2"):
             oasis_version = "5"
 
         mkdirp(self.__pkgdir)


### PR DESCRIPTION
```
# spack install oasis3-mct@OASIS3-MCT_5.2 target=x86_64 %oneapi@2025.2.0

==> Installing oasis3-mct-OASIS3-MCT_5.2-wmgsjyjeljmkhcqka4uu352jgezz45pg [47/47]
==> No binary for oasis3-mct-OASIS3-MCT_5.2-wmgsjyjeljmkhcqka4uu352jgezz45pg found: installing from source
==> No patches needed for oasis3-mct
==> oasis3-mct: Executing phase: 'edit'
==> oasis3-mct: Executing phase: 'build'
==> oasis3-mct: Executing phase: 'install'
==> oasis3-mct: Successfully installed oasis3-mct-OASIS3-MCT_5.2-wmgsjyjeljmkhcqka4uu352jgezz45pg
  Stage: 23.73s.  Edit: 0.00s.  Build: 46.03s.  Install: 0.01s.  Post-install: 0.09s.  Total: 1m 9.96s
[+] /opt/release/linux-rocky8-x86_64/oneapi-2025.2.0/oasis3-mct-OASIS3-MCT_5.2-wmgsjyjeljmkhcqka4uu352jgezz45pg
```

