### PR TITLE
`build-ci v3`: Update Infra For `spack v1`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,10 @@ jobs:
       PACKAGES_ROOT_DIR: spack_repo/access/nri/packages
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-      builtin-spack-packages-ref: ${{ steps.set-refs.outputs.builtin-spack-packages-ref }}
-      access-spack-packages-ref: ${{ steps.set-refs.outputs.access-spack-packages-ref }}
-      spack-config-ref: ${{ steps.set-refs.outputs.spack-config-ref }}
-      spack-ref: ${{ steps.set-refs.outputs.spack-ref }}
+      builtin-spack-packages-ref: ${{ inputs.builtin-spack-packages-ref }}
+      access-spack-packages-ref: ${{ inputs.access-spack-packages-ref || github.event.pull_request.head.sha }}
+      spack-config-ref: ${{ inputs.spack-config-ref || steps.defaults.outputs.spack-config-ref }}
+      spack-ref: ${{ inputs.spack-ref || steps.defaults.outputs.spack-ref }}
     steps:
       - name: Checkout spack-packages
         uses: actions/checkout@v4
@@ -143,14 +143,6 @@ jobs:
 
           echo "spack-ref=$default_spack_ref" >> $GITHUB_OUTPUT
           echo "spack-config-ref=$default_spack_config_ref" >> $GITHUB_OUTPUT
-
-      - name: Set refs
-        id: set-refs
-        run: |
-          echo "builtin-spack-packages-ref=${{ inputs.builtin-spack-packages-ref }}" >> $GITHUB_OUTPUT
-          echo "access-spack-packages-ref=${{ inputs.access-spack-packages-ref || github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
-          echo "spack-config-ref=${{ inputs.spack-config-ref || steps.defaults.outputs.spack-config-ref }}" >> $GITHUB_OUTPUT
-          echo "spack-ref=${{ inputs.spack-ref || steps.defaults.outputs.spack-ref }}" >> $GITHUB_OUTPUT
 
   ci:
     name: CI


### PR DESCRIPTION
References issue ACCESS-NRI/build-ci#231 and PR ACCESS-NRI/build-ci#253
References project https://github.com/orgs/ACCESS-NRI/projects/37

> [!IMPORTANT]
> This PR is a major update to the infrastructure. See below for the prerequisites for this repository to be able to merge this PR.

> [!IMPORTANT]
> This major version change marks the end of major infrastructure updates for CI using `spack < 1.0`. They will still get bug fixes and non-breaking features if required.
> If you want to deploy to instances of `spack < 1.0`, you must use `build-ci v2`.
> If you want to deploy to instances of `spack >= 1.0`, you must use `build-ci v3`.

## Background

We are looking to transition `build-ci` to `v3`! This is due to a migration to `spack v1.X`, from `v0.X`, which offers many bug fixes, features, and optimisations.

One of these changes is the splitting of spacks core codebase from the builtin spack-packages repository, which means that we have another lever to tweak for our builds: the version of `spack`, `spack-config`, our `spack-packages` and the (new!) builtin `spack-packages`.

Since we want to leave open the possibility of forking the builtin `spack-packages`, we have also decided to rename `ACCESS-NRI/spack-packages` to `ACCESS-NRI/access-spack-packages`. See ACCESS-NRI/access-spack-packages#295 for more info.

Therefore this is a major version update, as there are the following changes to the inputs (and analogous changes to the workflow outputs):

* Deleted the optional `spack-packages-ref` input, which defaulted to `main` (in future, `api-v1`).
* Added the optional `access-spack-packages-ref` input, which defaults to the `api-v2` branch.
* Added the optional `builtin-spack-packages-ref` input, which defaults to the `main` branch.

This means that:

* If you want to use `container-image-version: :rocky-0.22-*`, or `spack-ref` < `releases/1.0`, you must stay on `v2` due to the input changes.
* If you want to use `container-image-version: :rocky-1.*-*`, or `spack-ref` >= `releases/1.0`, you must migrate to `v3` due to the input changes.

It is possible to test across these versions of `spack` if required, via a mix of workflow versions. Ask @CodeGat if you need this functionality.

## Features

The main new features include:

* **Proper Spack v1 Support**: Users now can tweak both the builtin `spack-packages` repository, as well as our own `access-spack-packages` repository. All of the bugfixes, features and optimisations added since `0.22` are available to us for future inclusion into `build-ci`.

## Prerequisites for Merging

- [x] Update `build-ci` entrypoints to `v3` (this PR!)
- [x] Make sure that all SPRs work with this `v3` infra
