### PR TITLE
access-mom6: Add 'mom6_solo' variant to install MOM6 solo executable

### DIFF
--- a/packages/access-mom6/package.py
+++ b/packages/access-mom6/package.py
@@ -35,6 +35,12 @@ class AccessMom6(CMakePackage):
         default=True,
         description="Install MOM6 as library for Access3 models"
     )
+    variant(
+        "mom6_solo",
+        default=False,
+        description="Install MOM6 solo executable",
+        when="@2025.07.001:"
+    )
 
     depends_on("access3-share", when="+access3")
     depends_on("cmake@3.18:", type="build")
@@ -51,6 +57,7 @@ class AccessMom6(CMakePackage):
             self.define_from_variant("MOM6_OPENMP", "openmp"),
             self.define_from_variant("MOM6_ASYMMETRIC", "asymmetric_mem"),
             self.define_from_variant("MOM6_ACCESS3", "access3"),
+            self.define_from_variant("MOM6_SOLO"),
         ]
 
         return args


### PR DESCRIPTION
This PR adds a variant `mom6_solo` to the access-mom6 SPR. The variant can be used to also build a MOM6 executable using the `solo_driver`.

### Related PRs

- The required changes to the MOM6 CMake build system are [here](https://github.com/ACCESS-NRI/MOM6/pull/36).
- A prerelease deployment of ACCESS-OM3 using this variant is [here](https://github.com/ACCESS-NRI/ACCESS-OM3/pull/166).