### PR TITLE
`issm`: No strict_timestamps for zip archive in `+py-tools` variant

### DIFF
--- a/packages/issm/package.py
+++ b/packages/issm/package.py
@@ -251,7 +251,7 @@ class Issm(AutotoolsPackage):
                         py_files.append(join_path(root, file))
 
             # Create the ZIP archive
-            with zipfile.ZipFile(py_dst, "w", zipfile.ZIP_DEFLATED) as zf:
+            with zipfile.ZipFile(py_dst, "w", zipfile.ZIP_DEFLATED, strict_timestamps=False) as zf:
                 for src_path in py_files:
                     # Use only the filename inside the archive
                     arcname = src_path.split("/")[-1]


### PR DESCRIPTION
See failed run https://github.com/ACCESS-NRI/access-spack-packages/actions/runs/20229243475/job/58131871129#step:18:4403, specifically:

```
==> [2025-12-15-21:28:06.088750] issm: Executing phase: 'install'
==> [2025-12-15-21:28:22.250882] Error: ValueError: ZIP does not support timestamps before 1980

/opt/package_repos/3t2klr5/spack_repo/access/nri/packages/issm/package.py:260, in install:
        257                for src_path in py_files:
        258                    # Use only the filename inside the archive
        259                    arcname = src_path.split("/")[-1]
  >>    260                    zf.write(src_path, arcname=arcname)
```

## Background

When attempting to install `issm +py-tools` (see manifest here: https://github.com/ACCESS-NRI/access-spack-packages/actions/runs/20229243475/job/58131871129#step:17:20) as part of CI, it fails to create the zip archive due to Zipfile not supporting timestamps before 1980. 

When we look in the `$spack_stage/spack-stage-issm-access-release-mzzqhr4fjsd6tl5s5l5j5lwftkhqicyz/spack-src/src/m` directory (from https://github.com/ACCESS-NRI/access-spack-packages/blob/main/packages/issm/package.py#L228), we note that all the sources are from `1 Jan 1970` (unix epoch time) pointing to some issue with the modification time. 

One way to disregard this error is to make the timestamps less strict when instanciating the Zipfile class. 

## The PR

* `issm`: Make `strict_timestamps=False` when creating the `Zipfile` class for the `+py-tools` variant

