### PR TITLE
access-mom6: add 2026.01.000

### DIFF
--- a/packages/access-mom6/package.py
+++ b/packages/access-mom6/package.py
@@ -21,7 +21,7 @@ class AccessMom6(CMakePackage):
     # see license file in https://github.com/ACCESS-NRI/MOM6/blob/e92c971084e185cfd3902f18072320b45d583a54/LICENSE.md
     license("LGPL-3.0-only", checked_by="minghangli-uni")
 
-    version("stable", branch="2025.07", preferred=True)   # need to update branch for new major versions
+    version("stable", branch="2026.01", preferred=True)   # need to update branch for new major versions
     version("2026.01.000", tag="2026.01.000", commit="3a82c07a999d51cf1cc645edd593d35871c2fba8")
     # NOTE: 2025.08.000 has been deprecated due to a bug: https://github.com/ACCESS-NRI/MOM6/issues/26
     version("2025.08.000", tag="2025.08.000", commit="bc51c1ba407f5ae669b5bbc94b027e852e2c6ac4", deprecated=True)


### PR DESCRIPTION
This PR adds the MOM6 version [2026.01.000](https://github.com/ACCESS-NRI/MOM6/releases/tag/2026.01.000) to the access-mom6 SPR.