### PR TITLE
Turn off gcc build-CI for access-esm1.6

### DIFF
--- a/.github/build-ci/manifests/access-esm1p6/intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/access-esm1p6/intel.spack.yaml.j2
@@ -1,8 +1,8 @@
-# This manifest is used by default for packages without a specific manifest under .github/build-ci/manifests/PACKAGE/*.j2
+# This manifest is the same as the default for the intel compiler. 
+# We provide a manifest in this folder to suppress the default build using the 
+# gcc compiler from occuring, due to https://github.com/ACCESS-NRI/access-spack-packages/issues/342
 spack:
   specs:
-  # package is defined in the workflows inputs.spack-manifest-data-pairs
-  # And the intel_compilers are defined in the standard_definitions.json data file
   - '{{ package }} %{{ intel_compiler }}'
   packages:
     all:

--- a/.github/build-ci/manifests/um7/intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/um7/intel.spack.yaml.j2
@@ -1,8 +1,8 @@
-# This manifest is used by default for packages without a specific manifest under .github/build-ci/manifests/PACKAGE/*.j2
+# This manifest is the same as the default for the intel compiler. 
+# We provide a manifest in this folder to suppress the default build using the 
+# gcc compiler from occuring, due to https://github.com/ACCESS-NRI/access-spack-packages/issues/342
 spack:
   specs:
-  # package is defined in the workflows inputs.spack-manifest-data-pairs
-  # And the intel_compilers are defined in the standard_definitions.json data file
   - '{{ package }} %{{ intel_compiler }}'
   packages:
     all:


### PR DESCRIPTION
Turns off access-esm1.6 %gcc builds which are failing, as noted in #342 

( I don't mess with access-esm1.5, due to https://github.com/ACCESS-NRI/access-spack-packages/issues/371)