### PR TITLE
Fix syntax for esm1.5 (doesn't use cable as a library)

### DIFF
--- a/.github/build-ci/manifests/access-esm1p5/intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/access-esm1p5/intel.spack.yaml.j2
@@ -3,8 +3,7 @@
 # gcc compiler from occuring, due to https://github.com/ACCESS-NRI/access-spack-packages/issues/342
 spack:
   specs:
-  - '{{ package }}@access-esm1.5 %{{ intel_compiler }}'
-  - '{{ package }}@access-esm1.6 %{{ intel_compiler }}'
+  - '{{ package }} %{{ intel_compiler }}'
   packages:
     all:
       require:

--- a/packages/um7/package.py
+++ b/packages/um7/package.py
@@ -56,7 +56,7 @@ class Um7(Package):
                 join_path(self.spec["oasis3-mct"].prefix.include, subdir)
                 for subdir in ["psmile.MPI1", "mct"]]
         ideps = ["gcom4", "netcdf-fortran"]
-        with when("@access-esm1.6"):
+        if self.spec.satisfies("@access-esm1.6"):
             ideps.append("cable")
         incs = [self.spec[d].prefix.include for d in ideps] + oasis3_incs
         for ipath in incs:
@@ -102,7 +102,7 @@ class Um7(Package):
         """
 
         ldeps = ["oasis3-mct", "netcdf-fortran", "dummygrib"]
-        with when("@access-esm1.6"):
+        if self.spec.satisfies("@access-esm1.6"):
             ldeps.append("cable")
         libs = " ".join([self._get_linker_args(spec, d) for d in ldeps] + ["-lgcom"])
 
@@ -151,7 +151,7 @@ class Um7(Package):
         # string for older versions of UM7 which include CABLE as
         # source code.
         CABLE_excl_deps = ""
-        with when("@access-esm1.6"):
+        if self.spec.satisfies("@access-esm1.6"):
             CABLE_excl_deps = """
 excl_dep                                           USE::cable_def_types_mod
 excl_dep                                           USE::cbl_masks_mod


### PR DESCRIPTION
Closes #371 

This fixes a syntax error in the um7 package.

This also adds ci builds for access-esm1.5