### PR TITLE
The compiler flags for an optimised UM7 build

### DIFF
--- a/packages/um7/package.py
+++ b/packages/um7/package.py
@@ -140,7 +140,7 @@ class Um7(Package):
             FTRACEBACK = ""
             FDEBUG = ""
             FG = ""
-            FARCH = "-xCORE-AVX512"
+            FARCH = "-march=cascadelake -mtune=sapphirerapids"
             FOBLANK = ""
 
         # FCM tries to find all instances of USE and include them as

--- a/packages/um7/package.py
+++ b/packages/um7/package.py
@@ -236,12 +236,12 @@ tool::cppflags
 tool::cppkeys                                      {CPPKEYS}
 tool::fc                                           mpif90
 tool::fflags                                       {FO}  -g   -traceback  {FDEBUG} -i8 -r8      -fp-model precise {FFLAGS}
-tool::fflags::control::coupling::dump_received     {FO} {FG} {FTRACEBACK} {FDEBUG}         -mp1 -fp-model strict  {FFLAGS}
-tool::fflags::control::coupling::dump_sent         {FO} {FG} {FTRACEBACK} {FDEBUG}         -mp1 -fp-model strict  {FFLAGS}
-tool::fflags::control::coupling::oasis3_atmos_init {FO} {FG} {FTRACEBACK} {FDEBUG} -i4 -r8 -mp1 -fp-model strict  {FFLAGS}
-tool::fflags::control::top_level::atm_step         {FO}   -g  {FTRACEBACK} {FDEBUG} -i8 -r8 -mp1 -fp-model strict  {FFLAGS}
-tool::fflags::control::top_level::set_atm_pointers {FO}   -g   -traceback  {FDEBUG} -i8 -r8      -fp-model strict -ftz -std95
-tool::fflags::control::top_level::u_model          {FO}   -g  {FTRACEBACK} {FDEBUG} -i8 -r8 -mp1 -fp-model strict  {FFLAGS}
+tool::fflags::control::coupling::dump_received     {FO} {FG} {FTRACEBACK} {FDEBUG}         -mp1 -fp-model precise  {FFLAGS}
+tool::fflags::control::coupling::dump_sent         {FO} {FG} {FTRACEBACK} {FDEBUG}         -mp1 -fp-model precise  {FFLAGS}
+tool::fflags::control::coupling::oasis3_atmos_init {FO} {FG} {FTRACEBACK} {FDEBUG} -i4 -r8 -mp1 -fp-model precise  {FFLAGS}
+tool::fflags::control::top_level::atm_step         {FO}   -g {FTRACEBACK} {FDEBUG} -i8 -r8 -mp1 -fp-model precise  {FFLAGS}
+tool::fflags::control::top_level::set_atm_pointers {FO}   -g  -traceback  {FDEBUG} -i8 -r8      -fp-model precise -ftz -std95
+tool::fflags::control::top_level::u_model          {FO}   -g {FTRACEBACK} {FDEBUG} -i8 -r8 -mp1 -fp-model precise  {FFLAGS}
 tool::fpp                                          cpp
 tool::fppflags                                     -P -traditional
 tool::fppkeys                                      {CPPKEYS}

--- a/packages/um7/package.py
+++ b/packages/um7/package.py
@@ -136,7 +136,7 @@ class Um7(Package):
             FARCH = ""
             FOBLANK = "-O0"
         else:
-            FO = "-O2"
+            FO = "-O2 -unroll"
             FTRACEBACK = ""
             FDEBUG = ""
             FG = ""

--- a/packages/um7/package.py
+++ b/packages/um7/package.py
@@ -239,9 +239,9 @@ tool::fflags                                       {FO}  -g   -traceback  {FDEBU
 tool::fflags::control::coupling::dump_received     {FO} {FG} {FTRACEBACK} {FDEBUG}         -mp1 -fp-model strict  {FFLAGS}
 tool::fflags::control::coupling::dump_sent         {FO} {FG} {FTRACEBACK} {FDEBUG}         -mp1 -fp-model strict  {FFLAGS}
 tool::fflags::control::coupling::oasis3_atmos_init {FO} {FG} {FTRACEBACK} {FDEBUG} -i4 -r8 -mp1 -fp-model strict  {FFLAGS}
-tool::fflags::control::top_level::atm_step         -O0   -g  {FTRACEBACK} {FDEBUG} -i8 -r8 -mp1 -fp-model strict  {FFLAGS}
-tool::fflags::control::top_level::set_atm_pointers -O0   -g   -traceback  {FDEBUG} -i8 -r8      -fp-model strict -ftz -std95
-tool::fflags::control::top_level::u_model          -O0   -g  {FTRACEBACK} {FDEBUG} -i8 -r8 -mp1 -fp-model strict  {FFLAGS}
+tool::fflags::control::top_level::atm_step         {FO}   -g  {FTRACEBACK} {FDEBUG} -i8 -r8 -mp1 -fp-model strict  {FFLAGS}
+tool::fflags::control::top_level::set_atm_pointers {FO}   -g   -traceback  {FDEBUG} -i8 -r8      -fp-model strict -ftz -std95
+tool::fflags::control::top_level::u_model          {FO}   -g  {FTRACEBACK} {FDEBUG} -i8 -r8 -mp1 -fp-model strict  {FFLAGS}
 tool::fpp                                          cpp
 tool::fppflags                                     -P -traditional
 tool::fppkeys                                      {CPPKEYS}


### PR DESCRIPTION
Details for the optimised build are in [this issue](https://github.com/ACCESS-NRI/ACCESS-ESM1.6/issues/44). This corresponded to build 4, but I have created a new branch and attempted to follow the branch-naming guidelines.

Should be squash-merged, and once this is merged, the original `update_compiler_flags` branch can be deleted.