### PR TITLE
Add default CICE5 builds when using CMake

### DIFF
--- a/.github/build-ci/manifests/cice5/access-esm1.6-intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/cice5/access-esm1.6-intel.spack.yaml.j2
@@ -2,6 +2,7 @@ spack:
   specs:
     - 'access-esm1p6 ^cice5 nxglob=360 nyglob=300 blckx=15 blcky=300 mxblcks=1'
     - 'access-esm1p6 ^cice5 build_system=makefile'
+    - 'access-esm1p6 ^cice5 build_system=cmake'
   packages:
     python:
       require:

--- a/.github/build-ci/manifests/cice5/access-om2+deterministic-intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/cice5/access-om2+deterministic-intel.spack.yaml.j2
@@ -1,6 +1,6 @@
 spack:
   specs:
-    - 'access-om2 +deterministic ^cice5 build_system=cmake nxglob=360 nyglob=300 blckx=15 blcky=300 mxblcks=1'
+    - 'access-om2 +deterministic ^cice5 build_system=cmake nxglob=360 nyglob=300 blckx=15 blcky=150 mxblcks=2'
     - 'access-om2 +deterministic ^cice5 build_system=makefile'
   packages:
     python:

--- a/.github/build-ci/manifests/cice5/access-om2~deterministic-intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/cice5/access-om2~deterministic-intel.spack.yaml.j2
@@ -2,6 +2,7 @@ spack:
   specs:
     - 'access-om2 ~deterministic ^cice5 build_system=cmake nxglob=360 nyglob=300 blckx=15 blcky=300 mxblcks=1'
     - 'access-om2 ~deterministic ^cice5 build_system=makefile'
+    - 'access-om2 ~deterministic ^cice5 build_system=cmake'
   packages:
     python:
       require:

--- a/spack_repo/access/nri/packages/cice5/package.py
+++ b/spack_repo/access/nri/packages/cice5/package.py
@@ -7,13 +7,27 @@ from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
 from spack.package import *
 
+# These are the default layouts, inc 3 executables for OM2
+# alternatively, supply the 5 layouts variant to produce 1 executable
+OM2_LAYOUTS = [
+        {"nxglob": "360", "nyglob": "300", "blckx": "15", "blcky": "300", "mxblcks": "1"},
+        {"nxglob": "1440", "nyglob": "1080", "blckx": "30", "blcky": "27", "mxblcks": "4"},
+        {"nxglob": "3600", "nyglob": "2700", "blckx": "40", "blcky": "30", "mxblcks": "12"},
+    ]
+ESM1P6_LAYOUTS = [
+    {"nxglob": "360", "nyglob": "300", "blckx": "30", "blcky": "300", "mxblcks": "1"},
+]
+
+
 def _int_validator(s):
     """Test a string variant is a valid integer """
-    if (s.isdigit() and int(s) > 0):
-        return True
-    else:
-        print(f"ERROR: {s} not a valid integer")
-        return False
+    if (s != "none"):
+        if (s.isdigit() and int(s) > 0):
+            return True
+        else:
+            print(f"ERROR: {s} not a valid integer")
+            return False
+
 
 class Cice5(CMakePackage, MakefilePackage):
     """The Los Alamos sea ice model (CICE) is the result of an effort to develop 
@@ -32,7 +46,7 @@ class Cice5(CMakePackage, MakefilePackage):
     version("access-om2", branch="master")
     version("access-esm1.6", branch="access-esm1.6")
 
-    # by default, keep existing processor layout defined in makefile
+    # by default, keep existing processor layout
     # if nxglob, nyglob, blckx, blcky, mxblcks are supplied, then spack will switch to cmake
     build_system("makefile", "cmake", default="makefile")
 
@@ -113,25 +127,62 @@ class Cice5(CMakePackage, MakefilePackage):
         depends_on("libaccessom2+deterministic", when="+deterministic")
         depends_on("libaccessom2~deterministic", when="~deterministic")
 
+
 class CMakeBuilder(cmake.CMakeBuilder):
 
+    phases = ["set_layouts", "cmake_build_install"]
+
+    def set_layouts(self, pkg, spec, prefix):
+        layout_variants = OM2_LAYOUTS[0].keys()
+
+        # if all 5 layouts variants are available, set the layouts dict
+        if all([
+            self.spec.variants[variant].value != 'none' 
+            for variant in layout_variants
+        ]):
+            layouts = [{variant: self.spec.variants[variant].value
+                for variant in layout_variants}]
+        # else if no layout variants are available, use the defaults
+        elif all([
+            self.spec.variants[variant].value == 'none' 
+            for variant in layout_variants
+        ]):
+            if self.spec.variants["model"].value == "access-esm1.6":
+                layouts = ESM1P6_LAYOUTS
+            else:
+                layouts = OM2_LAYOUTS
+        else:
+            raise Error(f"All of {layout_variants} "
+                        "variants must be set if any are set")
+
+        self._all_layouts = layouts
+
     def cmake_args(self):
+        # combine the normal cmake build phases, so its easier to produce multiple builds
+        # cmake_args is called during super().cmake()
         if self.spec.variants["model"].value == "access-esm1.6":
             args = [self.define("CICE_DRIVER", "access")]
         else:  # access-om2
             args = [self.define("CICE_DRIVER", "auscom")]
 
         args.extend([
+            self.define("CICE_NXGLOB", self._layout['nxglob']),
+            self.define("CICE_NYGLOB", self._layout['nyglob']),
+            self.define("CICE_BLCKX", self._layout['blckx']),
+            self.define("CICE_BLCKY", self._layout['blcky']),
+            self.define("CICE_MXBLCKS", self._layout['mxblcks']),
             self.define_from_variant("CICE_IO", "io_type"),
-            self.define_from_variant("CICE_NXGLOB", "nxglob"),
-            self.define_from_variant("CICE_NYGLOB", "nyglob"),
-            self.define_from_variant("CICE_BLCKX", "blckx"),
-            self.define_from_variant("CICE_BLCKY", "blcky"),
-            self.define_from_variant("CICE_MXBLCKS", "mxblcks"),
             self.define_from_variant("CICE_DETERMINISTIC", "deterministic"),
         ])
 
         return args
+
+    def cmake_build_install(self, pkg, spec, prefix):
+        for layout in self._all_layouts:
+            self._layout = layout
+            super().cmake(pkg, spec, prefix)
+            super().build(pkg, spec, prefix)
+            super().install(pkg, spec, prefix)
 
 
 class MakefileBuilder(makefile.MakefileBuilder):
@@ -216,7 +267,6 @@ class MakefileBuilder(makefile.MakefileBuilder):
         self.__deps["includes"] = " ".join([istr] + [(spec[d].headers).cpp_flags for d in ideps])
 
         self.__deps["ldflags"] = " ".join([lstr] + [self.get_linker_args(spec, d) for d in ldeps])
-
 
     def edit(self, pkg, spec, prefix):
 

--- a/spack_repo/access/nri/packages/cice5/package.py
+++ b/spack_repo/access/nri/packages/cice5/package.py
@@ -8,7 +8,7 @@ from spack_repo.builtin.build_systems.makefile import MakefilePackage
 from spack.package import *
 
 # These are the default layouts, inc 3 executables for OM2
-# alternatively, supply the 5 layout variant to produce 1 executable
+# alternatively, supply the 5 layout variants to produce 1 executable
 OM2_LAYOUTS = [
         {"nxglob": "360", "nyglob": "300", "blckx": "15", "blcky": "300", "mxblcks": "1"},
         {"nxglob": "1440", "nyglob": "1080", "blckx": "30", "blcky": "27", "mxblcks": "4"},


### PR DESCRIPTION
This change adds support for doing multiple CMake builds within a spack package.

For model releases & deployments, we use the defaults in this package. For OM2 this produces three executables.

For development, optimisation work etc, the user can specify the grid & processor layout, but only one executable per spack spec.

All current behaviour is unmodified, except that setting `build_system=cmake` without providing the layout variants is now supported, and builds the default layouts.

In the unlikely case we changed the default build layouts such that the executable names were not unique, some builds would be missing.

```
ll .../spack/om2/release/linux-rocky8-x86_64_v4/oneapi-2025.2.0/cice5-2026.01.000-etrk3e4vjol5algldjnsorw2hy3piagf/bin

-rwxr-xr-x 1 as2285 tm70 18651432 Feb 11 13:11 cice_auscom_1440x1080_30x27.exe
-rwxr-xr-x 1 as2285 tm70 19013264 Feb 11 13:11 cice_auscom_3600x2700_40x30.exe
-rwxr-xr-x 1 as2285 tm70 17885064 Feb 11 13:11 cice_auscom_360x300_15x300.exe
```

closes #382 