### PR TITLE
Change gcom to use GitHub

### DIFF
--- a/.github/build-ci/manifests/gcom/gcc.spack.yaml.j2
+++ b/.github/build-ci/manifests/gcom/gcc.spack.yaml.j2
@@ -1,0 +1,17 @@
+# This manifest is used by default for packages without a specific manifest under .github/build-ci/manifests/PACKAGE/*.j2
+spack:
+  specs:
+  # package is defined in the workflows inputs.spack-manifest-data-pairs
+  # gcc_compiler_ver is defined in the standard_definitions.json data file
+  - '{{ package }}'
+  packages:
+    gcc:
+      require:
+        - '{{ gcc_compiler_ver }}'
+    all:
+      require:
+        - '%access_gcc'
+        - 'target={{ target }}'
+  concretizer:
+    unify: false
+  view: false

--- a/.github/build-ci/manifests/gcom/intel.spack.yaml.j2
+++ b/.github/build-ci/manifests/gcom/intel.spack.yaml.j2
@@ -1,0 +1,20 @@
+# This manifest is used by default for packages without a specific manifest under .github/build-ci/manifests/PACKAGE/*.j2
+spack:
+  specs:
+  # package is defined in the workflows inputs.spack-manifest-data-pairs
+  # intel_compiler_ver is defined in the standard_definitions.json data file
+  - '{{ package }}'
+  packages:
+    python:
+      require:
+        - '@3.11.14'
+    intel-oneapi-compilers-classic:
+      require:
+        - '{{ intel_compiler_ver }}'
+    all:
+      require:
+        - '%access_intel'
+        - 'target={{ target }}'
+  concretizer:
+    unify: false
+  view: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,6 @@ jobs:
           - package: {template_value: "access-issm"}
           - package: {template_value: "access-test"}
           - package: {template_value: "coastri-roms"}
-          - package: {template_value: "gcom"}
           - package: {template_value: "gcom4"}
           - package: {template_value: "um"}
     uses: access-nri/build-ci/.github/workflows/ci.yml@v3

--- a/spack_repo/access/nri/packages/gcom/package.py
+++ b/spack_repo/access/nri/packages/gcom/package.py
@@ -7,19 +7,18 @@ class Gcom(Package):
     GCOM is a wrapper around multiprocessing libraries such as MPI
     """
 
-    homepage = "https://code.metoffice.gov.uk/trac/gcom"
-    svn = "file:///g/data/ki32/mosrs/gcom/main/trunk"
+    homepage = "https://github.com/ACCESS-NRI/gcom"
+    git = "https://github.com/ACCESS-NRI/gcom"
 
     maintainers("scottwales", "paulleopardi")
 
-    # See 'fcm kp fcm:gcom.xm' for release versions
-    version("7.8", revision=1147)
-    version("7.9", revision=1166)
-    version("8.0", revision=1181)
-    version("8.1", revision=1215)
-    version("8.2", revision=1251)
-    version("8.3", revision=1288)
-    version("8.4", revision=1386)
+    version("7.8", tag="vn7.8")
+    version("7.9", tag="vn7.9")
+    version("8.0", tag="vn8.0")
+    version("8.1", tag="vn8.1")
+    version("8.2", tag="vn8.2")
+    version("8.3", tag="vn8.3")
+    version("8.4", tag="vn8.4")
 
     variant("mpi", default=True, description="Build with MPI")
 


### PR DESCRIPTION
Closes #384 

Tested by building gcom 7.9 through 8.4. Example:
```
==> openmpi@4.1.7 : has external module in ['openmpi/4.1.7']
[+] /apps/openmpi/4.1.7 (external openmpi-4.1.7-q3qnxmz5w6lrtvw5wa5zjjwj2ynfysdv)
==> intel-oneapi-compilers-classic@2021.10.0 : has external module in ['intel-compiler/2021.10.0']
[+] /apps/intel-ct/wrapper (external intel-oneapi-compilers-classic-2021.10.0-rjzvcxkrnsiza6vps4v2kkgfn2swyhfs)
[+] /usr (external glibc-2.28-vuczjrbyzfif5nzgt5gqbrdrzaioihy6)
[+] /usr (external glibc-2.28-rmko4qyyetyn6neqs7tnuusqbllgwbnb)
[+] /g/data/tm70/pcl851/src/ACCESS-NRI/release/linux-x86_64/compiler-wrapper-1.0-spro2dgnjjawulhw7fxxrqskm73cf4dd
[+] /g/data/tm70/pcl851/src/ACCESS-NRI/release/linux-rocky8-x86_64_v4/intel-2021.10.0/fcm-2021.05.0-lij5ulytklskb7bxlqve6f2g5cmcxmtq
==> Installing gcom-7.9-t5dgyx6lagyo6y7p6lwx55khkvfnnls2 [7/7]
==> No patches needed for gcom
==> gcom: Executing phase: 'install'
==> gcom: Successfully installed gcom-7.9-t5dgyx6lagyo6y7p6lwx55khkvfnnls2
  Stage: 9.84s.  Install: 2m 17.25s.  Post-install: 0.21s.  Total: 2m 29.16s
[+] /g/data/tm70/pcl851/src/ACCESS-NRI/release/linux-x86_64_v4/gcom-7.9-t5dgyx6lagyo6y7p6lwx55khkvfnnls2
```