### PR TITLE
Replace -xCORE-AVX2 with -mavx2

### DIFF
--- a/spack_repo/access/nri/packages/access_mocsy/package.py
+++ b/spack_repo/access/nri/packages/access_mocsy/package.py
@@ -134,7 +134,7 @@ Fflags: -I${{includedir}}
             self._libname,
             "FC=" + pkg.spec["mpi"].mpifc,
             # Copied from MOM5/bin/mkmf.template.nci
-            "FCFLAGS=-fno-alias -safe-cray-ptr -fpe0 -ftz -assume byterecl -i4 -r8 -traceback -nowarn -check noarg_temp_created -assume nobuffered_io -convert big_endian -grecord-gcc-switches -align all -g3 -O2 -xCORE-AVX2 -debug all -check none",
+            "FCFLAGS=-fno-alias -safe-cray-ptr -fpe0 -ftz -assume byterecl -i4 -r8 -traceback -nowarn -check noarg_temp_created -assume nobuffered_io -convert big_endian -grecord-gcc-switches -align all -g3 -O2 -mavx2 -debug all -check none",
             "F90=" + pkg.spec["mpi"].mpifc
         )
         self._create_pkgconf(spec, prefix)

--- a/spack_repo/access/nri/packages/access_mocsy/package.py
+++ b/spack_repo/access/nri/packages/access_mocsy/package.py
@@ -134,7 +134,7 @@ Fflags: -I${{includedir}}
             self._libname,
             "FC=" + pkg.spec["mpi"].mpifc,
             # Copied from MOM5/bin/mkmf.template.nci
-            "FCFLAGS=-fno-alias -safe-cray-ptr -fpe0 -ftz -assume byterecl -i4 -r8 -traceback -nowarn -check noarg_temp_created -assume nobuffered_io -convert big_endian -grecord-gcc-switches -align all -g3 -O2 -mavx2 -debug all -check none",
+            "FCFLAGS=-fno-alias -safe-cray-ptr -fpe0 -ftz -assume byterecl -i4 -r8 -traceback -nowarn -check noarg_temp_created -assume nobuffered_io -convert big_endian -grecord-gcc-switches -align all -g3 -O2 -debug all -check none",
             "F90=" + pkg.spec["mpi"].mpifc
         )
         self._create_pkgconf(spec, prefix)

--- a/spack_repo/access/nri/packages/cice4/package.py
+++ b/spack_repo/access/nri/packages/cice4/package.py
@@ -110,7 +110,7 @@ LDFLAGS    := $(FFLAGS) {LDFLAGS}
         # Based on https://github.com/coecms/access-esm-build-gadi/blob/master/patch/Macros.Linux.raijin.nci.org.au-mct
         config["intel"] = f"""
 ifeq ($(DEBUG), yes)
-    FFLAGS     := -r8 -i4 -O0 -g -align all -w -ftz -convert big_endian -assume byterecl -no-vec -xCORE-AVX2 -fp-model precise
+    FFLAGS     := -r8 -i4 -O0 -g -align all -w -ftz -convert big_endian -assume byterecl -no-vec -mavx2 -fp-model precise
 else
     FFLAGS     := -r8 -i4 -O2 -align all -w -ftz -convert big_endian -assume byterecl -no-vec -xCORE-AVX512 -fp-model precise
 endif

--- a/spack_repo/access/nri/packages/cice4/package.py
+++ b/spack_repo/access/nri/packages/cice4/package.py
@@ -110,7 +110,7 @@ LDFLAGS    := $(FFLAGS) {LDFLAGS}
         # Based on https://github.com/coecms/access-esm-build-gadi/blob/master/patch/Macros.Linux.raijin.nci.org.au-mct
         config["intel"] = f"""
 ifeq ($(DEBUG), yes)
-    FFLAGS     := -r8 -i4 -O0 -g -align all -w -ftz -convert big_endian -assume byterecl -no-vec -mavx2 -fp-model precise
+    FFLAGS     := -r8 -i4 -O0 -g -align all -w -ftz -convert big_endian -assume byterecl -no-vec -fp-model precise
 else
     FFLAGS     := -r8 -i4 -O2 -align all -w -ftz -convert big_endian -assume byterecl -no-vec -xCORE-AVX512 -fp-model precise
 endif

--- a/spack_repo/access/nri/packages/cice5/package.py
+++ b/spack_repo/access/nri/packages/cice5/package.py
@@ -309,11 +309,11 @@ class MakefileBuilder(makefile.MakefileBuilder):
         libs = self.__deps["ldflags"]
 
         # TODO: https://github.com/ACCESS-NRI/ACCESS-OM/issues/12
-        NCI_OPTIM_FLAGS = "-g3 -O2 -axCORE-AVX2 -debug all -check none -traceback -assume buffered_io"
+        NCI_OPTIM_FLAGS = "-g3 -O2 -mavx2 -debug all -check none -traceback -assume buffered_io"
         CFLAGS = "-c -O2"
         LDFLAGS = self.get_variant_value(spec.variants["direct_ldflags"].value)
         if "+deterministic" in self.spec:
-            NCI_OPTIM_FLAGS = "-g0 -O0 -axCORE-AVX2 -debug none -check none -assume buffered_io"
+            NCI_OPTIM_FLAGS = "-g0 -O0 -mavx2 -debug none -check none -assume buffered_io"
             CFLAGS = "-c -g0"
 
         if "+optimisation_report" in self.spec:

--- a/spack_repo/access/nri/packages/cice5/package.py
+++ b/spack_repo/access/nri/packages/cice5/package.py
@@ -309,11 +309,11 @@ class MakefileBuilder(makefile.MakefileBuilder):
         libs = self.__deps["ldflags"]
 
         # TODO: https://github.com/ACCESS-NRI/ACCESS-OM/issues/12
-        NCI_OPTIM_FLAGS = "-g3 -O2 -mavx2 -debug all -check none -traceback -assume buffered_io"
+        NCI_OPTIM_FLAGS = "-g3 -O2 -debug all -check none -traceback -assume buffered_io"
         CFLAGS = "-c -O2"
         LDFLAGS = self.get_variant_value(spec.variants["direct_ldflags"].value)
         if "+deterministic" in self.spec:
-            NCI_OPTIM_FLAGS = "-g0 -O0 -mavx2 -debug none -check none -assume buffered_io"
+            NCI_OPTIM_FLAGS = "-g0 -O0 -debug none -check none -assume buffered_io"
             CFLAGS = "-c -g0"
 
         if "+optimisation_report" in self.spec:

--- a/spack_repo/access/nri/packages/mom5/package.py
+++ b/spack_repo/access/nri/packages/mom5/package.py
@@ -199,11 +199,11 @@ class MakefileBuilder(makefile.MakefileBuilder):
             ldeps = ["oasis3-mct", "libaccessom2", "netcdf-c", "netcdf-fortran", "datetime-fortran"]
 
             # TODO: https://github.com/ACCESS-NRI/ACCESS-OM/issues/12
-            FFLAGS_OPT = "-g3 -O2 -mavx2 -debug all -check none -traceback"
-            CFLAGS_OPT = "-O2 -debug minimal -mavx2"
+            FFLAGS_OPT = "-g3 -O2 -debug all -check none -traceback"
+            CFLAGS_OPT = "-O2 -debug minimal"
             if self.spec.satisfies("+deterministic"):
-                FFLAGS_OPT = "-g0 -O0 -mavx2 -debug none -check none"
-                CFLAGS_OPT = "-O0 -debug none -mavx2"
+                FFLAGS_OPT = "-g0 -O0 -debug none -check none"
+                CFLAGS_OPT = "-O0 -debug none"
                 print("INFO: +deterministic applied")
 
         incs = " ".join([istr] + [(spec[d].headers).cpp_flags for d in ideps])

--- a/spack_repo/access/nri/packages/mom5/package.py
+++ b/spack_repo/access/nri/packages/mom5/package.py
@@ -199,11 +199,11 @@ class MakefileBuilder(makefile.MakefileBuilder):
             ldeps = ["oasis3-mct", "libaccessom2", "netcdf-c", "netcdf-fortran", "datetime-fortran"]
 
             # TODO: https://github.com/ACCESS-NRI/ACCESS-OM/issues/12
-            FFLAGS_OPT = "-g3 -O2 -xCORE-AVX2 -debug all -check none -traceback"
-            CFLAGS_OPT = "-O2 -debug minimal -xCORE-AVX2"
+            FFLAGS_OPT = "-g3 -O2 -mavx2 -debug all -check none -traceback"
+            CFLAGS_OPT = "-O2 -debug minimal -mavx2"
             if self.spec.satisfies("+deterministic"):
-                FFLAGS_OPT = "-g0 -O0 -xCORE-AVX2 -debug none -check none"
-                CFLAGS_OPT = "-O0 -debug none -xCORE-AVX2"
+                FFLAGS_OPT = "-g0 -O0 -mavx2 -debug none -check none"
+                CFLAGS_OPT = "-O0 -debug none -mavx2"
                 print("INFO: +deterministic applied")
 
         incs = " ".join([istr] + [(spec[d].headers).cpp_flags for d in ideps])

--- a/spack_repo/access/nri/packages/oasis3_mct/package.py
+++ b/spack_repo/access/nri/packages/oasis3_mct/package.py
@@ -115,13 +115,13 @@ Cflags: -I${{includedir}}/{k}
         config = {}
 
         # TODO: https://github.com/ACCESS-NRI/ACCESS-OM/issues/12
-        NCI_OPTIM_FLAGS = "-g3 -O2 -mavx2 -debug all -check none -traceback"
+        NCI_OPTIM_FLAGS = "-g3 -O2 -debug all -check none -traceback"
         CFLAGS = ""
         if "@access-esm1.5" in self.spec:
             NCI_OPTIM_FLAGS = "-g3 -O2 -xCORE-AVX512 -debug all -check none -traceback"
 
         if "+deterministic" in self.spec:
-            NCI_OPTIM_FLAGS = "-g0 -O0 -mavx2 -debug none -check none"
+            NCI_OPTIM_FLAGS = "-g0 -O0 -debug none -check none"
             CFLAGS = "-g0"
 
         if "+optimisation_report" in self.spec:

--- a/spack_repo/access/nri/packages/oasis3_mct/package.py
+++ b/spack_repo/access/nri/packages/oasis3_mct/package.py
@@ -115,13 +115,13 @@ Cflags: -I${{includedir}}/{k}
         config = {}
 
         # TODO: https://github.com/ACCESS-NRI/ACCESS-OM/issues/12
-        NCI_OPTIM_FLAGS = "-g3 -O2 -axCORE-AVX2 -debug all -check none -traceback"
+        NCI_OPTIM_FLAGS = "-g3 -O2 -mavx2 -debug all -check none -traceback"
         CFLAGS = ""
         if "@access-esm1.5" in self.spec:
             NCI_OPTIM_FLAGS = "-g3 -O2 -xCORE-AVX512 -debug all -check none -traceback"
 
         if "+deterministic" in self.spec:
-            NCI_OPTIM_FLAGS = "-g0 -O0 -axCORE-AVX2 -debug none -check none"
+            NCI_OPTIM_FLAGS = "-g0 -O0 -mavx2 -debug none -check none"
             CFLAGS = "-g0"
 
         if "+optimisation_report" in self.spec:

--- a/spack_repo/access/nri/packages/um7/package.py
+++ b/spack_repo/access/nri/packages/um7/package.py
@@ -144,7 +144,7 @@ class Um7(Package):
             FTRACEBACK = ""
             FDEBUG = ""
             FG = ""
-            FARCH = "-mavx2"
+            FARCH = ""
             FOBLANK = ""
 
         # FCM tries to find all instances of USE and include them as

--- a/spack_repo/access/nri/packages/um7/package.py
+++ b/spack_repo/access/nri/packages/um7/package.py
@@ -144,7 +144,7 @@ class Um7(Package):
             FTRACEBACK = ""
             FDEBUG = ""
             FG = ""
-            FARCH = "-xCORE-AVX512"
+            FARCH = "-mavx2"
             FOBLANK = ""
 
         # FCM tries to find all instances of USE and include them as


### PR DESCRIPTION
This PR replaces all instances of `-xCORE-AVX2` in SPRs with `-mavx2`. See #387 for justification.

Closes #387