### PR TITLE
Add commits to gcom versions

### DIFF
--- a/spack_repo/access/nri/packages/gcom/package.py
+++ b/spack_repo/access/nri/packages/gcom/package.py
@@ -12,13 +12,13 @@ class Gcom(Package):
 
     maintainers("scottwales", "paulleopardi")
 
-    version("7.8", tag="vn7.8")
-    version("7.9", tag="vn7.9")
-    version("8.0", tag="vn8.0")
-    version("8.1", tag="vn8.1")
-    version("8.2", tag="vn8.2")
-    version("8.3", tag="vn8.3")
-    version("8.4", tag="vn8.4")
+    version("7.8", tag="vn7.8", commit="65c857cc3201833360ff62b285e49082378dae42")
+    version("7.9", tag="vn7.9", commit="6319ae016dcadc192842a06178f3dbd21a8af64f")
+    version("8.0", tag="vn8.0", commit="5a122e9e2147c9a7486a00b9588356eb65324af9")
+    version("8.1", tag="vn8.1", commit="e061e2787bd643d9a65679f153fb8e3ffd9d3186")
+    version("8.2", tag="vn8.2", commit="fd143bb38e21fe03c7150c0754852c80e15df3d4")
+    version("8.3", tag="vn8.3", commit="b7b890a181d8e31e4e80b731b9f8ad9a6e1a8bed")
+    version("8.4", tag="vn8.4", commit="f4fa92eb4af4f1e4cf9d608b441e3c96f77b6a6d")
 
     variant("mpi", default=True, description="Build with MPI")
 


### PR DESCRIPTION
Closes #392

Tested on Gadi as follows:
```
[pcl851@gadi-login-05 3t2klr5]$ spack uninstall gcom@8.3
    -- linux-rocky8-x86_64 / %c,fortran=intel@2021.10.0 -------------
    mhre726 gcom@8.3

==> 1 packages will be uninstalled. Do you want to proceed? [y/N] y
==> Successfully uninstalled gcom@8.3+mpi build_system=generic commit=b7b890a181d8e31e4e80b731b9f8ad9a6e1a8bed platform=linux os=rocky8 target=x86_64/mhre726
[pcl851@gadi-login-05 3t2klr5]$ spack install gcom@8.3%intel@2021.10.0
==> openmpi@4.1.7 : has external module in ['openmpi/4.1.7']
[+] /apps/openmpi/4.1.7 (external openmpi-4.1.7-q3qnxmz5w6lrtvw5wa5zjjwj2ynfysdv)
==> intel-oneapi-compilers-classic@2021.10.0 : has external module in ['intel-compiler/2021.10.0']
[+] /apps/intel-ct/wrapper (external intel-oneapi-compilers-classic-2021.10.0-rjzvcxkrnsiza6vps4v2kkgfn2swyhfs)
[+] /usr (external glibc-2.28-vuczjrbyzfif5nzgt5gqbrdrzaioihy6)
[+] /g/data/tm70/pcl851/spack/1.1/release/linux-x86_64/compiler-wrapper-1.0-spro2dgnjjawulhw7fxxrqskm73cf4dd
[+] /g/data/tm70/pcl851/spack/1.1/release/linux-x86_64/fcm-2021.05.0-t2zjdq6prcofscqzamgzazexwskb7do3
==> No binary for gcom-8.3-mhre726ibakq66cyxuxx5c2if75k3n4f found: installing from source
==> Installing gcom-8.3-mhre726ibakq66cyxuxx5c2if75k3n4f [6/6]
==> Using cached archive: /g/data/tm70/pcl851/spack/1.1/sourcecache/_source-cache/git/ACCESS-NRI/gcom/b7b890a181d8e31e4e80b731b9f8ad9a6e1a8bed.tar.gz
==> Warning: Using download cache instead of version control
  The required sources are normally checked out from a version control system, but have been archived in download cache: file:///g/data/tm70/pcl851/spack/1.1/sourcecache/_source-cache/git/ACCESS-NRI/gcom/b7b890a181d8e31e4e80b731b9f8ad9a6e1a8bed.tar.gz. Spack lacks a tree hash to verify the integrity of this archive. Make sure your download cache is in a secure location.
==> No patches needed for gcom
==> gcom: Executing phase: 'install'
==> gcom: Successfully installed gcom-8.3-mhre726ibakq66cyxuxx5c2if75k3n4f
  Stage: 0.90s.  Install: 2m 29.83s.  Post-install: 0.26s.  Total: 2m 31.66s
[+] /g/data/tm70/pcl851/spack/1.1/release/linux-x86_64/gcom-8.3-mhre726ibakq66cyxuxx5c2if75k3n4f
```