### PR TITLE
`issm`: Clamp mtime of  sources zipped up by `+py-tools`

### DIFF
--- a/spack_repo/access/nri/packages/issm/package.py
+++ b/spack_repo/access/nri/packages/issm/package.py
@@ -11,7 +11,7 @@ import zipfile
 import os
 import time
 
-ZIPFILE_MIN_DATE: tuple[int] = (1980, 1, 1, 0, 0, 0)
+ZIPFILE_MIN_DATE = (1980, 1, 1, 0, 0, 0)
 
 class Issm(AutotoolsPackage):
     """Ice-sheet and Sea-Level System Model.

--- a/spack_repo/access/nri/packages/issm/package.py
+++ b/spack_repo/access/nri/packages/issm/package.py
@@ -5,8 +5,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from turtle import st
-
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack.package import *
 import zipfile
@@ -282,7 +280,7 @@ class Issm(AutotoolsPackage):
         clamped_mtime_date = max(mtime_date, ZIPFILE_MIN_DATE)
 
         zinfo = zipfile.ZipInfo(archive_name, clamped_mtime_date)
-        
+
         # Since we're setting the zipinfo manually, we need to set some other aspects...
         zinfo.compress_type = zip_file.compression
         # mode is both file type and perms. We only want the perms (the low 16 bits).

--- a/spack_repo/access/nri/packages/issm/package.py
+++ b/spack_repo/access/nri/packages/issm/package.py
@@ -5,11 +5,15 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from turtle import st
+
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack.package import *
 import zipfile
 import os
+import time
 
+ZIPFILE_MIN_DATE: tuple[int] = (1980, 1, 1, 0, 0, 0)
 
 class Issm(AutotoolsPackage):
     """Ice-sheet and Sea-Level System Model.
@@ -259,7 +263,33 @@ class Issm(AutotoolsPackage):
                 for src_path in py_files:
                     # Use only the filename inside the archive
                     arcname = src_path.split("/")[-1]
-                    zf.write(src_path, arcname=arcname)
+
+                    zinfo = self._clamped_mtime(src_path, arcname, zf)
+
+                    with open(src_path, "rb") as f:
+                        zf.writestr(zinfo, f.read())
+
+    def _clamped_mtime(self, file_path: str, archive_name: str, zip_file: zipfile.ZipFile) -> zipfile.ZipInfo:
+        # Since some sources during building are erroneously using unix epoch mtime (which errors out in
+        # python 3.6s implementation of zipfile when the mtime is before 1980),
+        # we clamp it to a supported date (1/1/1980).
+        stats = os.stat(file_path)
+        mtime = stats.st_mtime
+        mode = stats.st_mode
+
+        # This converts the unix-style seconds since epoch to a zipfile-understandable struct of (year, month, day, hour, min, sec)
+        mtime_date = time.localtime(mtime)[:6]
+        clamped_mtime_date = max(mtime_date, ZIPFILE_MIN_DATE)
+
+        zinfo = zipfile.ZipInfo(archive_name, clamped_mtime_date)
+        
+        # Since we're setting the zipinfo manually, we need to set some other aspects...
+        zinfo.compress_type = zip_file.compression
+        # mode is both file type and perms. We only want the perms (the low 16 bits).
+        # zipfile expects unix perms to be set in the upper 16 bits, so we shift them up by 16.
+        zinfo.external_attr = (mode & 0xFFFF) << 16
+
+        return zinfo
 
     # --------------------------------------------------------------------
     # Run environment - set ISSM_DIR and PYTHONPATH
@@ -277,4 +307,3 @@ class Issm(AutotoolsPackage):
         if "+py-tools" in self.spec:
             env.prepend_path("PYTHONPATH", join_path(self.prefix, "python-tools.zip"))
             env.prepend_path("PYTHONPATH", join_path(self.prefix, "lib"))
-


### PR DESCRIPTION
See https://github.com/ACCESS-NRI/ACCESS-ISSM/actions/runs/22739327801

## Background

For some reason, `issm`s sources are sometimes given an `mtime` for unix epoch time. When attempting to zip them up with `python 3.6`s `zipfile` library, we get an error as `zipfile` can't zip things before 1980. Since we're on an old version of python before `zipfile.ZipFile(..., strict_timestamps=False)`, we have to do it ourselves. 

## The PR

* Manually clamp the mtime of the files to be > 1980, by modifting the `zipfile.ZipInfo` directly. We need to set some other aspects as well (namely, compression type and permissions).

## Testing

The build succeeded below without error!