### PR TITLE
access-mocsy: remove version gtracers and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The namespace of the ACCESS Spack package repository is `access.nri`.
 ## How to utilise this package repository
 
 > [!NOTE]
-> `$SPACK_ROOT` and `$ACCESS_SPACK_PACKAGE_PATH` are substituted in all paths to make these instructions installation independent.
+> `$SPACK_ROOT` and `$ACCESS_SPACK_PACKAGES_PATH` are substituted in all paths to make these instructions installation independent.
 
 If you are not using ACCESS-NRI's `spack-config`, a default installation of Spack will have a single package repository (`builtin`):
 ```bash
@@ -23,13 +23,13 @@ $ spack list libaccessom2
 
 To use the SPRs in this repository, **first** check if your Spack instance already includes this repository (`spack repo list`). If not, then add it manually:
 ```
-spack repo add https://github.com/ACCESS-NRI/access-spack-packages $ACCESS_SPACK_PACKAGE_PATH
+spack repo add https://github.com/ACCESS-NRI/access-spack-packages $ACCESS_SPACK_PACKAGES_PATH
 ```
 and then confirm it has been added correctly:
 ```
 $ spack repo list
 [+] builtin       v2.2    $SPACK_ROOT/../package_repos/fncqgg4/repos/spack_repo/builtin
-[+] access.nri    v2.0    $ACCESS_SPACK_PACKAGE_PATH/spack_repo/access/nri
+[+] access.nri    v2.0    $ACCESS_SPACK_PACKAGES_PATH/spack_repo/access/nri
 ```
 Now, the `libaccessom2` package should be available to install
 ```
@@ -37,6 +37,8 @@ $ spack list libaccessom2
 libaccessom2
 ==> 1 packages
 ```
+
+Spack does a shallow clone of the repositories. To restore the full functionality of the git repository, run: `git fetch --unshallow $ACCESS_SPACK_PACKAGES_PATH`
 
 ## More information
 

--- a/spack_repo/access/nri/packages/access_mocsy/package.py
+++ b/spack_repo/access/nri/packages/access_mocsy/package.py
@@ -22,13 +22,15 @@ class AccessMocsy(CMakePackage, MakefilePackage):
     # https://github.com/ACCESS-NRI/mocsy/blob/master/LICENSE
     license("MIT", checked_by="dougiesquire")
 
-    # TODO: Delete the "gtracers" version once it is no longer being used anywhere.
-    version("gtracers", branch="gtracers")
     version("stable", branch="gtracers", preferred=True)
     version("2025.07.002", tag="2025.07.002", commit="bfbf7f87244bb42db53cd304ddfead567e990312")
     version("2025.07.001", tag="2025.07.001", commit="156b3c8f50562e20882c686988022e3ef19f8526")
     version("2025.07.000", tag="2025.07.000", commit="1e4bc055519a6446232dcff803e7b80e56c49424")
     version("2017.12.0", tag="2017.12.0", commit="385222c469942f0562b4c70b926dfdd8173138e7")
+
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
+    depends_on("mpi")
 
     build_system(conditional("cmake", when="@2025.07.000:"), "makefile", default="cmake")
 
@@ -52,11 +54,6 @@ class AccessMocsy(CMakePackage, MakefilePackage):
             description="Precision to use (1 or 2)",
             values=("1", "2"),
         )
-
-    depends_on("c", type="build")
-    depends_on("fortran", type="build")
-
-    depends_on("mpi")
 
 
 class CMakeBuilder(cmake.CMakeBuilder):


### PR DESCRIPTION
1. Test CI with this change
2. It doesn't look like version `gtracers` is still used: https://github.com/search?q=org%3AACCESS-NRI+gtracers&type=code