### PR TITLE
New versions for OM3 components

### DIFF
--- a/spack_repo/access/nri/packages/access3/package.py
+++ b/spack_repo/access/nri/packages/access3/package.py
@@ -18,6 +18,7 @@ KNOWN_CONF = (
 
 # tag,commit pairs for releases in access3-share git repository
 ACCESS3_VERSIONS = {
+    "2026.03.000": "825a3f4835bb088b12f68babe0149b017b16ba72",
     "2025.08.000": "f2f35ce5915e82a83899b69560d826deab53b668",
     "2025.03.1": "d28d8b3bb2d490920cabd48a87663de017ca6a18",
     "2025.03.0": "d61a88ac937092f6f8ee1215716e2d6a750161e3"

--- a/spack_repo/access/nri/packages/access_cice/package.py
+++ b/spack_repo/access/nri/packages/access_cice/package.py
@@ -20,7 +20,7 @@ class AccessCice(CMakePackage):
     license("BSD-3-Clause", checked_by="anton-seaice")
 
     version("stable", branch="CICE6.6.3-x", preferred=True)  # need to update branch for new major versions
-    version("CICE6.6.3-0", commit="e6f2bc4842fa8e1ad78cbe3542c1c84a3e673a83")
+    version("CICE6.6.3-0", tag="CICE6.6.3-0", commit="e6f2bc4842fa8e1ad78cbe3542c1c84a3e673a83")
     version("CICE6.6.1-0", tag="CICE6.6.1-0", commit="6bceb915e232f46a8c84992a3176b98ee0acd8b5")
     version("CICE6.6.0-3", tag="CICE6.6.0-3", commit="2c444bd9d2fad1f1df4d855debc2801d4b23487d")
     version("CICE6.6.0-1", tag="CICE6.6.0-1", commit="964a4455db3127d0c4681e6533f6d9733a5e8255")

--- a/spack_repo/access/nri/packages/access_cice/package.py
+++ b/spack_repo/access/nri/packages/access_cice/package.py
@@ -19,7 +19,8 @@ class AccessCice(CMakePackage):
 
     license("BSD-3-Clause", checked_by="anton-seaice")
 
-    version("stable", branch="CICE6.6.1-x", preferred=True)  # need to update branch for new major versions
+    version("stable", branch="CICE6.6.3-x", preferred=True)  # need to update branch for new major versions
+    version("CICE6.6.3-0", commit="e6f2bc4842fa8e1ad78cbe3542c1c84a3e673a83")
     version("CICE6.6.1-0", tag="CICE6.6.1-0", commit="6bceb915e232f46a8c84992a3176b98ee0acd8b5")
     version("CICE6.6.0-3", tag="CICE6.6.0-3", commit="2c444bd9d2fad1f1df4d855debc2801d4b23487d")
     version("CICE6.6.0-1", tag="CICE6.6.0-1", commit="964a4455db3127d0c4681e6533f6d9733a5e8255")

--- a/spack_repo/access/nri/packages/access_mom6/package.py
+++ b/spack_repo/access/nri/packages/access_mom6/package.py
@@ -23,6 +23,7 @@ class AccessMom6(CMakePackage):
     license("LGPL-3.0-only", checked_by="minghangli-uni")
 
     version("stable", branch="2026.01", preferred=True)   # need to update branch for new major versions
+    version("2026.01.001", tag="2026.01.001", commit="c664721ebd58c033964b502e7fcdcccd05f02947")
     version("2026.01.000", tag="2026.01.000", commit="3a82c07a999d51cf1cc645edd593d35871c2fba8")
     # NOTE: 2025.08.000 has been deprecated due to a bug: https://github.com/ACCESS-NRI/MOM6/issues/26
     version("2025.08.000", tag="2025.08.000", commit="bc51c1ba407f5ae669b5bbc94b027e852e2c6ac4", deprecated=True)

--- a/spack_repo/access/nri/packages/access_ww3/package.py
+++ b/spack_repo/access/nri/packages/access_ww3/package.py
@@ -17,6 +17,7 @@ class AccessWw3(CMakePackage):
     license("LGPL-3.0-only", checked_by="anton-seaice")
 
     version("stable", branch="dev/2025.08", preferred=True)   # need to update branch for new major versions
+    version("2026.03.000", tag="2026.03.000", commit="1845b8c17321e8625829f8edad763f44722cfeac")
     version("2025.08.000", tag="2025.08.000", commit="5ccdad475003c711ccb660039847759cc952519f")
     version("2025.03.0", tag="2025.03.0", commit="d980dececb8843da1769470f24bc633982073db6")
 

--- a/spack_repo/access/nri/packages/access_ww3/package.py
+++ b/spack_repo/access/nri/packages/access_ww3/package.py
@@ -16,7 +16,7 @@ class AccessWw3(CMakePackage):
     maintainers("anton-seaice", "harshula")
     license("LGPL-3.0-only", checked_by="anton-seaice")
 
-    version("stable", branch="dev/2025.08", preferred=True)   # need to update branch for new major versions
+    version("stable", branch="dev/2026.03", preferred=True)   # need to update branch for new major versions
     version("2026.03.000", tag="2026.03.000", commit="1845b8c17321e8625829f8edad763f44722cfeac")
     version("2025.08.000", tag="2025.08.000", commit="5ccdad475003c711ccb660039847759cc952519f")
     version("2025.03.0", tag="2025.03.0", commit="d980dececb8843da1769470f24bc633982073db6")


### PR DESCRIPTION
Updated versions for OM3 components, see Gadi build at https://github.com/ACCESS-NRI/ACCESS-OM3/pull/209#issuecomment-4064660836

Related to https://github.com/ACCESS-NRI/access-om3-configs/issues/1028