### PR TITLE
Fix spack install fiat@um

### DIFF
--- a/spack_repo/access/nri/packages/fiat/package.py
+++ b/spack_repo/access/nri/packages/fiat/package.py
@@ -22,7 +22,7 @@ class Fiat(CMakePackage):
     license("Apache-2.0")
 
     version("main", branch="main", no_cache=True)
-    version("um", branch="um", no_cache=True)
+    version("um", branch="um", tag="1.4.1-um", no_cache=True)
     version("1.2.0", sha256="758147410a4a3c493290b87443b4091660b915fcf29f7c4d565c5168ac67745f")
     version("1.1.0", sha256="58354e60d29a1b710bfcea9b87a72c0d89c39182cb2c9523ead76a142c695f82")
     version("1.0.0", sha256="45afe86117142831fdd61771cf59f31131f2b97f52a2bd04ac5eae9b2ab746b8")
@@ -49,6 +49,7 @@ class Fiat(CMakePackage):
 
     patch("intel_warnings_v110.patch", when="@0:1.1.0")
     patch("intel_warnings_v120.patch", when="@1.2.0:")
+    patch("intel_warnings_v120.patch", when="@um")
 
     def cmake_args(self):
         args = [


### PR DESCRIPTION
Closes #405 

Tested on Gadi login:
```
[pcl851@gadi-login-07 1.1]$ spack clean --downloads
==> Removing cached downloads
[pcl851@gadi-login-07 1.1]$ spack install --no-cache fiat@um target=x86_64_v4 %intel@2021.10.0
==> openmpi@4.1.7 : has external module in ['openmpi/4.1.7']
[+] /apps/openmpi/4.1.7 (external openmpi-4.1.7-q3qnxmz5w6lrtvw5wa5zjjwj2ynfysdv)
[+] /usr (external glibc-2.28-vuczjrbyzfif5nzgt5gqbrdrzaioihy6)
==> python@3.11.7 : has external module in ['python3/3.11.7']
[+] /apps/python3/3.11.7 (external python-3.11.7-7loeqvkv4rl3e3bgp7oqlrr4vyabqeaz)
==> intel-oneapi-compilers-classic@2021.10.0 : has external module in ['intel-compiler/2021.10.0']
[+] /apps/intel-ct/wrapper (external intel-oneapi-compilers-classic-2021.10.0-rjzvcxkrnsiza6vps4v2kkgfn2swyhfs)
[+] /usr (external perl-5.26.3-ywivpoaox2nafjxh4g4otfruzpyswj2p)
[+] /g/data/tm70/pcl851/spack/1.1/release/linux-x86_64/compiler-wrapper-1.0-spro2dgnjjawulhw7fxxrqskm73cf4dd
[+] /g/data/tm70/pcl851/spack/1.1/release/linux-x86_64/ncurses-6.5-20250705-eg6hnkr5hpgc4a7t2ydhckiydh4zj6s3
[+] /g/data/tm70/pcl851/spack/1.1/release/linux-x86_64/gmake-4.4.1-d5nd3lks3aornpidrxz2hbteka3uuk3r
[+] /g/data/tm70/pcl851/spack/1.1/release/linux-x86_64/eckit-1.32.3-upx5crwud5k7k34pcgzfskywythkexgy
[+] /g/data/tm70/pcl851/spack/1.1/release/linux-x86_64/nghttp2-1.67.1-55bkutwd4cociyqyy4ked6qawrml6t4d
[+] /g/data/tm70/pcl851/spack/1.1/release/linux-x86_64/zlib-ng-2.3.2-ilvuvnwmuk6d6ciz56tz5snlpvpmlqp4
[+] /g/data/tm70/pcl851/spack/1.1/release/linux-x86_64/fckit-0.14.1-ejqlvi22qv3swpvwnmygeontwl7evg2e
[+] /g/data/tm70/pcl851/spack/1.1/release/linux-x86_64/openssl-3.6.1-36qflnsb6guf4kyflkdquizsystxkyry
[+] /g/data/tm70/pcl851/spack/1.1/release/linux-x86_64/curl-8.18.0-ifgevaqlhgxvr2zskzaal4d6uyzvgh57
[+] /g/data/tm70/pcl851/spack/1.1/release/linux-x86_64/cmake-3.31.11-tvrh2bn62qu4sj76grodz4es673bpnm4
[+] /g/data/tm70/pcl851/spack/1.1/release/linux-x86_64/ecbuild-3.12.0-ad5brxdhickn5u5eaofzxd5m572phpb7
==> Installing fiat-um-wv6m3bpt5prc4lthglfkc4pg4vhncdtx [17/17]
==> Applied patch /g/data/tm70/pcl851/spack/1.1/access-spack-packages/spack_repo/access/nri/packages/fiat/intel_warnings_v120.patch
==> fiat: Executing phase: 'cmake'
==> fiat: Executing phase: 'build'
==> fiat: Executing phase: 'install'
==> fiat: Successfully installed fiat-um-wv6m3bpt5prc4lthglfkc4pg4vhncdtx
  Stage: 5.80s.  Cmake: 1m 11.01s.  Build: 27.80s.  Install: 11.34s.  Post-install: 0.72s.  Total: 1m 57.56s
[+] /g/data/tm70/pcl851/spack/1.1/release/linux-x86_64_v4/fiat-um-wv6m3bpt5prc4lthglfkc4pg4vhncdtx
```