### PR TITLE
access-mom6: Add conflict rule for access3 and mom6_solo

### DIFF
--- a/spack_repo/access/nri/packages/access_mom6/package.py
+++ b/spack_repo/access/nri/packages/access_mom6/package.py
@@ -46,6 +46,8 @@ class AccessMom6(CMakePackage):
         when="@2025.07.001:"
     )
 
+    conflicts("~access3", when="~mom6_solo", msg="At least one of access3 or mom6_solo must be enabled")
+
     depends_on("c", type="build")
     depends_on("fortran", type="build")
 


### PR DESCRIPTION
This PR adds a conflict rule for `~access3~mom6_solo`. Specifying neither means there is nothing to build