### PR TITLE
Add UM_CBL preproc directive to build config

### DIFF
--- a/spack_repo/access/nri/packages/um/model/vn13p1-am/rose-app.conf
+++ b/spack_repo/access/nri/packages/um/model/vn13p1-am/rose-app.conf
@@ -2,8 +2,8 @@
 #meta=um-fcm-make/vn13.1
 
 [env]
-keys_atmos_extra=CABLE_UM_ISSUE24 CABLE_UM_ISSUE18 
-keys_scm_extra=CABLE_UM_ISSUE24 CABLE_UM_ISSUE18 
+keys_atmos_extra=CABLE_UM_ISSUE24 CABLE_UM_ISSUE18 UM_CBL
+keys_scm_extra=CABLE_UM_ISSUE24 CABLE_UM_ISSUE18 UM_CBL
 keys_recon_extra=
 
 COUPLER=none


### PR DESCRIPTION
The CABLE in JULES, which is built by the `um` spack package, requires the `UM_CBL` preprocessor directive with the recent update of the code (see JULES [29fac91](https://github.com/ACCESS-NRI/JULES/commit/29fac917d90d5133b6fe9b879dc3f9d9860f7757)). Should be a temporary addition, until CABLE is included as a library.