### PR TITLE
access-generic-tracers: Add 2026.05.000

### DIFF
--- a/spack_repo/access/nri/packages/access_generic_tracers/package.py
+++ b/spack_repo/access/nri/packages/access_generic_tracers/package.py
@@ -22,6 +22,7 @@ class AccessGenericTracers(CMakePackage):
     # TODO: Delete the "main" version once it is no longer being used anywhere.
     version("main", branch="main")
     version("stable", branch="main", preferred=True)
+    version("2026.05.000", tag="2026.05.000", commit="8afe03201dbf9d6a1412f37159bf25e186fc36ee")
     version("2026.04.000", tag="2026.04.000", commit="19d9b3f4426ee5af30d10391622bf71503d471b7")
     version("2026.02.001", tag="2026.02.001", commit="6c471278026a97f3f19c54a56f680d170fefeb92")
     version("2026.02.000", tag="2026.02.000", commit="7f883aeb2628f8b462fa8c39a00bfec8f1ba4bdb")


### PR DESCRIPTION
This PR adds the new 2026.05.000 version to the access-generic-tracers SPR