### PR TITLE
access-test-component: add missing dependency on cmake

### DIFF
--- a/spack_repo/access/nri/packages/access_test_component/package.py
+++ b/spack_repo/access/nri/packages/access_test_component/package.py
@@ -26,7 +26,7 @@ class AccessTestComponent(CMakePackage):
     variant("mpi", default=True, description="Use MPI")
 
     depends_on("fortran", type="build")
-
+    depends_on("cmake@3.20:", type="build")
     depends_on("mpi", when="+mpi")
 
     root_cmakelists_dir = "stub"


### PR DESCRIPTION
*  access-test-component needs CMake: https://github.com/ACCESS-NRI/access-test-component/blob/main/stub/CMakeLists.txt
* It's important to use `type="build"` to provide Spack more flexibility when choosing the Spack hash of CMake.