### PR TITLE
Support Git commits in fetcher

### DIFF
--- a/spack_repo/access/nri/build_systems/um_base.py
+++ b/spack_repo/access/nri/build_systems/um_base.py
@@ -231,7 +231,7 @@ class UmBasePackage(Package):
         """
         return join_path(self.stage.source_path, "resources", project)
 
-    def _is_commit(ref):
+    def _is_commit(self, ref):
         """
         Treat ref as a version string and determine
         if it represents a Git commit.

--- a/spack_repo/access/nri/build_systems/um_base.py
+++ b/spack_repo/access/nri/build_systems/um_base.py
@@ -258,7 +258,7 @@ class UmBasePackage(Package):
             cfg = self._project_cfg[project]
             url = cfg["url"]
             ref = self._project_ref(project)
-            if _is_commit(ref):
+            if self._is_commit(ref):
                 fetcher = fs.from_kwargs(git=url, commit=ref)
                 print(f"The created fetcher is {fetcher}")
                 return fs.from_kwargs(git=url, commit=ref)

--- a/spack_repo/access/nri/build_systems/um_base.py
+++ b/spack_repo/access/nri/build_systems/um_base.py
@@ -8,6 +8,7 @@
 import configparser
 from spack_repo.builtin.build_systems.generic import Package
 from spack.util.executable import ProcessError
+from spack.version import ver, GitVersion
 from spack.package import *
 import spack.llnl.util.tty as tty
 import spack.util.git
@@ -230,6 +231,18 @@ class UmBasePackage(Package):
         """
         return join_path(self.stage.source_path, "resources", project)
 
+    def _is_commit(ref):
+        """
+        Treat ref as a version string and determine
+        if it represents a Git commit.
+        """
+        version = ver(ref)
+
+        if isinstance(version, GitVersion):
+            return version.is_commit
+        else:
+            return False
+
 
     @property
     def fetcher(self):
@@ -239,15 +252,19 @@ class UmBasePackage(Package):
         spec = self.spec
         model = spec.variants["model"].value
         if model in self.github_models:
-            # GitHub: Return a Git fetch strategy
+            # GitHub: Return a Git fetch strategy.
+            # Right now only tags and commits are supported.
             project = "um"
             cfg = self._project_cfg[project]
             url = cfg["url"]
             ref = self._project_ref(project)
-            return fs.from_kwargs(git=url, tag=ref)
+            if _is_commit(ref):
+                return fs.from_kwargs(git=url, commit=ref)
+            else:
+                return fs.from_kwargs(git=url, tag=ref)
         else:
-            # Subversion: Return a Subversion fetch strategy
-            # Recover the revision from the version definition if available
+            # Subversion: Return a Subversion fetch strategy.
+            # Recover the revision from the version definition if available.
             rev = None
             if spec.version in self.versions:
                 rev = self.versions[spec.version].get("revision")

--- a/spack_repo/access/nri/build_systems/um_base.py
+++ b/spack_repo/access/nri/build_systems/um_base.py
@@ -260,7 +260,6 @@ class UmBasePackage(Package):
             ref = self._project_ref(project)
             if self._is_commit(ref):
                 fetcher = fs.from_kwargs(git=url, commit=ref)
-                print(f"The created fetcher is {fetcher}")
                 return fs.from_kwargs(git=url, commit=ref)
             else:
                 return fs.from_kwargs(git=url, tag=ref)
@@ -577,7 +576,6 @@ class UmBasePackage(Package):
         project : str
             Project name (e.g. 'jules').
         """
-        print("Got to the _dynamic_resource stage")
         project_cfg = self._project_cfg[project]
         url = project_cfg["url"]
         ref = self._project_ref(project)

--- a/spack_repo/access/nri/build_systems/um_base.py
+++ b/spack_repo/access/nri/build_systems/um_base.py
@@ -259,7 +259,6 @@ class UmBasePackage(Package):
             url = cfg["url"]
             ref = self._project_ref(project)
             if self._is_commit(ref):
-                fetcher = fs.from_kwargs(git=url, commit=ref)
                 return fs.from_kwargs(git=url, commit=ref)
             else:
                 return fs.from_kwargs(git=url, tag=ref)

--- a/spack_repo/access/nri/build_systems/um_base.py
+++ b/spack_repo/access/nri/build_systems/um_base.py
@@ -259,6 +259,8 @@ class UmBasePackage(Package):
             url = cfg["url"]
             ref = self._project_ref(project)
             if _is_commit(ref):
+                fetcher = fs.from_kwargs(git=url, commit=ref)
+                print(f"The created fetcher is {fetcher}")
                 return fs.from_kwargs(git=url, commit=ref)
             else:
                 return fs.from_kwargs(git=url, tag=ref)
@@ -575,6 +577,7 @@ class UmBasePackage(Package):
         project : str
             Project name (e.g. 'jules').
         """
+        print("Got to the _dynamic_resource stage")
         project_cfg = self._project_cfg[project]
         url = project_cfg["url"]
         ref = self._project_ref(project)


### PR DESCRIPTION
Closes #428 

Use `is_commit` in `fetcher` to determine whether to use the `commit` or the `tag` keyword argument to `fs.from_kwargs`.
