### PR TITLE
access_test & access_test_component: MPI is not optional

### DIFF
--- a/spack_repo/access/nri/packages/access_test/package.py
+++ b/spack_repo/access/nri/packages/access_test/package.py
@@ -19,9 +19,6 @@ class AccessTest(BundlePackage):
 
     version("latest")
 
-    variant("mpi", default=True, description="MPI build")
-
-    depends_on("access-test-component+mpi", when="+mpi", type="run")
-    depends_on("access-test-component~mpi", when="~mpi", type="run")
+    depends_on("access-test-component", type="run")
 
     # There is no need for install() since there is no code.

--- a/spack_repo/access/nri/packages/access_test_component/package.py
+++ b/spack_repo/access/nri/packages/access_test_component/package.py
@@ -23,11 +23,9 @@ class AccessTestComponent(CMakePackage):
 
     version("main", branch="main", no_cache=True)
 
-    variant("mpi", default=True, description="Use MPI")
-
     depends_on("fortran", type="build")
     depends_on("cmake@3.20:", type="build")
-    depends_on("mpi", when="+mpi")
+    depends_on("mpi", type=("build", "link", "run"))
 
     root_cmakelists_dir = "stub"
 


### PR DESCRIPTION
* https://github.com/ACCESS-NRI/access-test-component/blob/19cbd388607dc3d1f4d989e1b3b1e3b73445d131/stub/CMakeLists.txt#L11
* We are using ACCESS-TEST to debug Spack concretizer issues, so we need to make sure the SPR is 100% accurate.