### PR TITLE
access-mom6: Add 2026.05.000

### DIFF
--- a/spack_repo/access/nri/packages/access_mom6/package.py
+++ b/spack_repo/access/nri/packages/access_mom6/package.py
@@ -22,7 +22,8 @@ class AccessMom6(CMakePackage):
     # see license file in https://github.com/ACCESS-NRI/MOM6/blob/e92c971084e185cfd3902f18072320b45d583a54/LICENSE.md
     license("LGPL-3.0-only", checked_by="minghangli-uni")
 
-    version("stable", branch="2026.01", preferred=True)   # need to update branch for new major versions
+    version("stable", branch="2026.05", preferred=True)   # need to update branch for new major versions
+    version("2026.05.000", tag="2026.05.000", commit="1300cda7cd1aeda5f41a10738e52ca2958dcb7ea")
     version("2026.01.001", tag="2026.01.001", commit="c664721ebd58c033964b502e7fcdcccd05f02947")
     version("2026.01.000", tag="2026.01.000", commit="3a82c07a999d51cf1cc645edd593d35871c2fba8")
     # NOTE: 2025.08.000 has been deprecated due to a bug: https://github.com/ACCESS-NRI/MOM6/issues/26


### PR DESCRIPTION
This PR adds the new 2026.05.000 version to the access-mom6 SPR