### PR TITLE
Auto-tag default `api-*` branch with `YEAR.MONTH.00MINOR` format

### DIFF
--- a/.github/workflows/default-branch-tagger.yml
+++ b/.github/workflows/default-branch-tagger.yml
@@ -45,16 +45,24 @@ jobs:
         id: generate
         # Our tags are in the format YYYY.MM.00MINOR (eg. 2026.05.000).
         # The new tag will be in the form CURRENT_YEAR.CURRENT_MONTH.00MINOR, where MINOR is
-        # determined by looking at the existing tags for the current year and month and
+        # determined by looking at the latest existing tag for the current year and month and
         # incrementing the minor version by 1.
         run: |
           current_year_month=$(date +'%Y.%m')
           echo "Current year/month: ${current_year_month}"
 
-          tags_in_current_year_month=$(git tag --list "${current_year_month}.*" | wc -l)
-          echo "Tags in ${current_year_month}: ${tags_in_current_year_month}"
+          latest_tag_in_current_year_month=$(git tag --list "${current_year_month}.*" --sort=version:refname | tail -n 1)
+          echo "Latest tag in ${current_year_month}: ${latest_tag_in_current_year_month:-<none>}"
 
-          padded_minor_version=$(printf "%03d" ${tags_in_current_year_month})
+          if [ -n "${latest_tag_in_current_year_month}" ]; then
+            latest_minor_version=${latest_tag_in_current_year_month##*.}
+            # We need to treat the 00MINOR portion as a base-10 number to avoid misinterpretation as octal arithmetic
+            next_minor_version=$((10#${latest_minor_version} + 1))
+          else
+            next_minor_version=0
+          fi
+
+          padded_minor_version=$(printf "%03d" "${next_minor_version}")
           echo "Padded minor version: ${padded_minor_version}"
 
           tag="${current_year_month}.${padded_minor_version}"

--- a/.github/workflows/default-branch-tagger.yml
+++ b/.github/workflows/default-branch-tagger.yml
@@ -12,6 +12,7 @@ on:
 concurrency:
   group: default-branch-tagger-${{ github.ref }}
   cancel-in-progress: false
+  queue: max
 
 jobs:
   tag:

--- a/.github/workflows/default-branch-tagger.yml
+++ b/.github/workflows/default-branch-tagger.yml
@@ -72,6 +72,10 @@ jobs:
       - name: Push tag
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          MESSAGE_PATH: ${{ runner.temp }}/msg.txt
         run: |
-          git tag ${{ steps.generate.outputs.tag }} -m "Generated as part of ${{ env.RUN_URL }}"
+          git show --no-patch --format=%B HEAD >> ${{ env.MESSAGE_PATH }}
+          echo "Generated as part of ${{ env.RUN_URL }}" >> ${{ env.MESSAGE_PATH }}
+
+          git tag ${{ steps.generate.outputs.tag }} -F ${{ env.MESSAGE_PATH }}
           git push --tags

--- a/.github/workflows/default-branch-tagger.yml
+++ b/.github/workflows/default-branch-tagger.yml
@@ -1,0 +1,76 @@
+name: Tag
+run-name: Tag ${{ github.sha }}
+on:
+  push:
+    branches:
+      # We run on all api-v* branches even though we only care about the default branch,
+      # because we can't use a github.event.repository.default_branch expression here.
+      - api-v*
+
+# Potential for a tagging race-condition if multiple commits are pushed in rapid succession - wait for each workflow
+# of this kind to finish before running the next one!
+concurrency:
+  group: default-branch-tagger-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    name: Tag
+    # There is potential for tagging ambiguity if we are tagging on non-default api-v* branches
+    # like api-v1 - this should be resolved by the maintainer manually.
+    if: github.event.repository.default_branch == github.ref_name
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Import Commit-Signing Key
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd  # v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.GH_ACTIONS_BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GH_ACTIONS_BOT_GPG_PASSPHRASE }}
+          git_config_global: true
+          git_committer_name: ${{ vars.GH_ACTIONS_BOT_GIT_USER_NAME }}
+          git_committer_email: ${{ vars.GH_ACTIONS_BOT_GIT_USER_EMAIL }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
+
+      - name: Generate new tag
+        id: generate
+        # Our tags are in the format YYYY.MM.00MINOR (eg. 2026.05.000).
+        # The new tag will be in the form CURRENT_YEAR.CURRENT_MONTH.00MINOR, where MINOR is
+        # determined by looking at the existing tags for the current year and month and
+        # incrementing the minor version by 1.
+        run: |
+          current_year_month=$(date +'%Y.%m')
+          echo "Current year/month: ${current_year_month}"
+
+          tags_in_current_year_month=$(git tag --list "${current_year_month}.*" | wc -l)
+          echo "Tags in ${current_year_month}: ${tags_in_current_year_month}"
+
+          padded_minor_version=$(printf "%03d" ${tags_in_current_year_month})
+          echo "Padded minor version: ${padded_minor_version}"
+
+          tag="${current_year_month}.${padded_minor_version}"
+
+          echo "::notice::New tag generated: ${tag}"
+          echo "tag=${tag}" >> $GITHUB_OUTPUT
+
+      - name: Check tag does not exist
+        run: |
+          if git rev-parse "${{ steps.generate.outputs.tag }}"; then
+            echo "::error::Generated tag ${{ steps.generate.outputs.tag }} already exists in the repository. Please check existing tags or tag manually."
+            exit 1
+          fi
+
+      - name: Push tag
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          git tag ${{ steps.generate.outputs.tag }} -m "Generated as part of ${{ env.RUN_URL }}"
+          git push --tags

--- a/README.md
+++ b/README.md
@@ -45,3 +45,5 @@ Spack does a shallow clone of the repositories. To restore the full functionalit
 * The Spack package repository that was used with pre-v1.0 Spack is available in the [api-v1 branch](https://github.com/ACCESS-NRI/access-spack-packages/tree/api-v1)
 
 * For more information see the extensive [spack documentation](https://spack.readthedocs.io/en/latest/repositories.html) on how to utilise repository files.
+
+* This repository utilizes automatic tagging on the default branch, upon merging, in the form `YEAR.MONTH.00MINOR` (for example, `2026.05.001`). See the [workflow file](./.github/workflows/default-branch-tagger.yml) for more information.


### PR DESCRIPTION
Closes #36

## Background

Currently users have to manually tag their `api-v*` branch commits so they can be used in MDRs. This can be automated for the default branch. 

It is not automated for non-default `api-v*` branches as there is a possibility of tagging ambiguity that should be resolved manually.

## The PR

* Add a new workflow that will automatically tag on push to default `api-v*` branch.

## Testing

To test, I moved the tag generation into a file and allowed input of something other than the current month, to test the functionality:

<details>
<summary>Script file</summary>

```bash
#!/bin/bash

current_year_month=${1-$(date +'%Y.%m')}
echo "Current year/month: ${current_year_month}"


latest_tag_in_current_year_month=$(git tag --list "${current_year_month}.*" --sort=version:refname | tail -n 1)
echo "Latest tag in ${current_year_month}: ${latest_tag_in_current_year_month:-<none>}"


if [ -n "${latest_tag_in_current_year_month}" ]; then
  latest_minor_version=${latest_tag_in_current_year_month##*.}
  next_minor_version=$((10#${latest_minor_version} + 1))
else
  next_minor_version=0
fi

padded_minor_version=$(printf "%03d" "${next_minor_version}")
echo "Padded minor version: ${padded_minor_version}"

tag="${current_year_month}.${padded_minor_version}"
echo "::notice::New tag generated: ${tag}"
```

</details>

### Current Month (1 tag)

```bash
$ ./test-script.sh 
Current year/month: 2026.06
Latest tag in 2026.06: 2026.06.000
Padded minor version: 001
::notice::New tag generated: 2026.06.001
```

### Previous Month (6 tags)

```bash
$ ./test-script.sh 2026.05
Current year/month: 2026.05
Latest tag in 2026.05: 2026.05.005
Padded minor version: 006
::notice::New tag generated: 2026.05.006
```

### Future Month (no tags)

```bash
$ ./test-script.sh 2027.01
Current year/month: 2027.01
Latest tag in 2027.01: <none>
Padded minor version: 000
::notice::New tag generated: 2027.01.000
```