### PR TITLE
Add missing dependency on cmake with the version

### DIFF
--- a/spack_repo/access/nri/packages/access_fms/package.py
+++ b/spack_repo/access/nri/packages/access_fms/package.py
@@ -42,6 +42,7 @@ class AccessFms(CMakePackage):
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
 
+    depends_on("cmake@3.12:", type="build")
     depends_on("netcdf-c")
     depends_on("netcdf-fortran")
     depends_on("mpi")

--- a/spack_repo/access/nri/packages/access_generic_tracers/package.py
+++ b/spack_repo/access/nri/packages/access_generic_tracers/package.py
@@ -50,6 +50,7 @@ class AccessGenericTracers(CMakePackage):
 
     depends_on("fortran", type="build")
 
+    depends_on("cmake@3.20:", type="build")
     depends_on("mpi")
     depends_on("access-mocsy@2025.07.001:")  # >= 2025.07.001 for CMake BS with "mocsy" target name
     # TODO: Make conditional once Spack v0.23 or newer is used. The newer

--- a/spack_repo/access/nri/packages/access_mocsy/package.py
+++ b/spack_repo/access/nri/packages/access_mocsy/package.py
@@ -42,6 +42,7 @@ class AccessMocsy(CMakePackage, MakefilePackage):
     )
 
     with when("build_system=cmake"):
+        depends_on("cmake@3.22:", type="build")
         variant(
             "build_type",
             default="RelWithDebInfo",

--- a/spack_repo/access/nri/packages/cable/package.py
+++ b/spack_repo/access/nri/packages/cable/package.py
@@ -49,6 +49,7 @@ class Cable(CMakePackage):
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
 
+    depends_on("cmake@3.24.2:", type="build")
     depends_on("netcdf-fortran@4.5.2:")
     depends_on("mpi", when="+mpi")
 

--- a/spack_repo/access/nri/packages/cice5/package.py
+++ b/spack_repo/access/nri/packages/cice5/package.py
@@ -97,6 +97,8 @@ class Cice5(CMakePackage, MakefilePackage):
         variant("blckx", default="none", values=_int_validator, description="Size of computational blocks in x")
         variant("blcky", default="none", values=_int_validator, description="Size of computational blocks in y")
         variant("mxblcks", default="none", values=_int_validator, description="Max number of blocks per task")
+        depends_on("cmake@3.18:", type="build")
+
 
     depends_on("c", type="build")
     depends_on("fortran", type="build")

--- a/spack_repo/access/nri/packages/fiat/package.py
+++ b/spack_repo/access/nri/packages/fiat/package.py
@@ -42,6 +42,7 @@ class Fiat(CMakePackage):
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
 
+    depends_on("cmake@3.12:", type=("build"))
     depends_on("ecbuild", type=("build"))
     depends_on("mpi", when="+mpi")
     depends_on("eckit", when="+fckit")

--- a/spack_repo/access/nri/packages/mom5/package.py
+++ b/spack_repo/access/nri/packages/mom5/package.py
@@ -40,6 +40,7 @@ class Mom5(CMakePackage, MakefilePackage):
     )
 
     with when("build_system=cmake"):
+        depends_on("cmake@3.18:", type="build")
         variant("build_type", default="RelWithDebInfo",
             description="CMake build type",
             values=("Debug", "Release", "RelWithDebInfo")


### PR DESCRIPTION
Spack upstream pointed out:
https://github.com/spack/spack-packages/blob/1ff98344f91f223211ad1f8b9c4858fb4c54e8fc/repos/spack_repo/builtin/build_systems/cmake.py#L169-L197

i.e. Spack will automatically add `depends_on("cmake", type="build")` when `"build_system=cmake"`, however, it does not contain a minimum CMake version. It may be safer to explicitly add it with the minimum CMake version.