### PR TITLE
Remove makefile support from mom5 and use tag-based versions

### DIFF
--- a/.github/build-ci/data/exclude.json
+++ b/.github/build-ci/data/exclude.json
@@ -8,5 +8,6 @@
 	"access-ram3",
 	"access-issm",
 	"access-test",
-	"coastri-roms"
+	"coastri-roms",
+	"cice4"
 ]

--- a/spack_repo/access/nri/packages/access_esm1p5/package.py
+++ b/spack_repo/access/nri/packages/access_esm1p5/package.py
@@ -6,7 +6,7 @@ from spack_repo.builtin.build_systems.bundle import BundlePackage
 from spack.package import *
 
 class AccessEsm1p5(BundlePackage):
-    """ACCESS-ESM1.5 bundle contains the coupled UM7, CICE4 and MOM5 models.
+    """ACCESS-ESM1.5 is DEPRECATED. Please use ACCESS-ESM1.6. ACCESS-ESM1.5 bundle contains the coupled UM7, CICE4 and MOM5 models.
 
     ACCESS-ESM1.5 comprises of:
 
@@ -27,9 +27,14 @@ class AccessEsm1p5(BundlePackage):
 
     version("latest")
 
-    depends_on("cice4", type="run")
-    depends_on("mom5@access-esm1.5", type="run")
+    # NOTE: The commented out lines below are only for documentation purposes:
+    # depends_on("cice4", type="run")
+    # depends_on("mom5@access-esm1.5", type="run")
     # um7 is in a private repository
-    depends_on("um7@access-esm1.5", type="run")
+    # depends_on("um7@access-esm1.5", type="run")
+    conflicts(
+        "@latest",
+        msg="access-esm1.5 is only available in access-spack-packages versions older than 2026.08.000. Refer to https://github.com/ACCESS-NRI/ACCESS-ESM1.5 for instructions on how to build access-esm1.5."
+    )
 
     # There is no need for install() since there is no code.

--- a/spack_repo/access/nri/packages/access_esm1p6/package.py
+++ b/spack_repo/access/nri/packages/access_esm1p6/package.py
@@ -48,7 +48,7 @@ class AccessEsm1p6(BundlePackage):
     depends_on("cice5 model=access-esm1.6", type="run")
     depends_on("mom5 model=access-esm1.6", type="run")
     # um7 is in a private repository
-    depends_on("um7@access-esm1.5", type="run", when="um=access-esm1.5")
-    depends_on("um7@access-esm1.6", type="run", when="um=access-esm1.6")
+    depends_on("um7@2024.10.17", type="run", when="um=access-esm1.5")
+    depends_on("um7", type="run", when="um=access-esm1.6")
 
     # There is no need for install() since there is no code.

--- a/spack_repo/access/nri/packages/access_esm1p6/package.py
+++ b/spack_repo/access/nri/packages/access_esm1p6/package.py
@@ -46,7 +46,7 @@ class AccessEsm1p6(BundlePackage):
     )
 
     depends_on("cice5 model=access-esm1.6", type="run")
-    depends_on("mom5@access-esm1.6", type="run")
+    depends_on("mom5 model=access-esm1.6", type="run")
     # um7 is in a private repository
     depends_on("um7@access-esm1.5", type="run", when="um=access-esm1.5")
     depends_on("um7@access-esm1.6", type="run", when="um=access-esm1.6")

--- a/spack_repo/access/nri/packages/access_fms/package.py
+++ b/spack_repo/access/nri/packages/access_fms/package.py
@@ -23,8 +23,12 @@ class AccessFms(CMakePackage):
 
     maintainers("harshula")
 
-    version("main", branch="main")
-    version("mom5", branch="mom5", preferred=True)
+    version("stable", branch="mom5", preferred=True)
+    version(
+        "2025.08.000",
+        tag="mom5-2025.08.000",
+        commit="bf5f05bbf817b0168773fb2737e9d707c989fb43"
+    )
 
     variant("gfs_phys", default=False, sticky=True, description="Use GFS Physics")
     variant("large_file", default=False, sticky=True, description="Enable compiler definition -Duse_LARGEFILE.")

--- a/spack_repo/access/nri/packages/access_generic_tracers/package.py
+++ b/spack_repo/access/nri/packages/access_generic_tracers/package.py
@@ -19,8 +19,6 @@ class AccessGenericTracers(CMakePackage):
 
     maintainers("harshula", "dougiesquire")
 
-    # TODO: Delete the "main" version once it is no longer being used anywhere.
-    version("main", branch="main")
     version("stable", branch="main", preferred=True)
     version("2026.05.000", tag="2026.05.000", commit="8afe03201dbf9d6a1412f37159bf25e186fc36ee")
     version("2026.04.000", tag="2026.04.000", commit="19d9b3f4426ee5af30d10391622bf71503d471b7")
@@ -41,7 +39,7 @@ class AccessGenericTracers(CMakePackage):
         sticky=True,
         description="Build shared/dynamic libraries"
     )
-    # NOTE: access-fms@mom5 should be used in OM2, ESM1.5 and ESM1.6 to preserve
+    # NOTE: access-fms should be used in OM2, ESM1.5 and ESM1.6 to preserve
     # answers with previous releases
     variant(
         "use_access_fms",

--- a/spack_repo/access/nri/packages/access_om2/package.py
+++ b/spack_repo/access/nri/packages/access_om2/package.py
@@ -25,7 +25,7 @@ class AccessOm2(BundlePackage):
     depends_on("libaccessom2~deterministic", when="~deterministic", type="run")
     depends_on("cice5+deterministic model=access-om2", when="+deterministic", type="run")
     depends_on("cice5~deterministic model=access-om2", when="~deterministic", type="run")
-    depends_on("mom5+deterministic", when="+deterministic", type="run")
-    depends_on("mom5~deterministic", when="~deterministic", type="run")
+    depends_on("mom5+deterministic model=access-om2", when="+deterministic", type="run")
+    depends_on("mom5~deterministic model=access-om2", when="~deterministic", type="run")
 
     # There is no need for install() since there is no code.

--- a/spack_repo/access/nri/packages/access_om2_bgc/package.py
+++ b/spack_repo/access/nri/packages/access_om2_bgc/package.py
@@ -23,15 +23,23 @@ class AccessOm2Bgc(BundlePackage):
 
     depends_on("libaccessom2+deterministic", when="+deterministic", type="run")
     depends_on("libaccessom2~deterministic", when="~deterministic", type="run")
-    depends_on("cice5+deterministic", when="+deterministic", type="run")
-    depends_on("cice5~deterministic", when="~deterministic", type="run")
     depends_on(
-        "mom5@legacy-access-om2-bgc+deterministic",
+        "cice5+deterministic model=access-om2",
         when="+deterministic",
         type="run"
     )
     depends_on(
-        "mom5@legacy-access-om2-bgc~deterministic",
+        "cice5~deterministic model=access-om2",
+        when="~deterministic",
+        type="run"
+    )
+    depends_on(
+        "mom5+deterministic model=access-om2-legacy-bgc",
+        when="+deterministic",
+        type="run"
+    )
+    depends_on(
+        "mom5~deterministic model=access-om2-legacy-bgc",
         when="~deterministic",
         type="run"
     )

--- a/spack_repo/access/nri/packages/cice4/package.py
+++ b/spack_repo/access/nri/packages/cice4/package.py
@@ -10,7 +10,7 @@ from spack.package import *
 
 # https://spack.readthedocs.io/en/latest/build_systems/makefilepackage.html
 class Cice4(MakefilePackage):
-    """The Los Alamos sea ice model (CICE) is the result of an effort to develop a computationally efficient sea ice component for a fully coupled atmosphere-land global climate model."""
+    """cice4 is DEPRECATED. Please use cice5. The Los Alamos sea ice model (CICE) is the result of an effort to develop a computationally efficient sea ice component for a fully coupled atmosphere-land global climate model."""
 
     homepage = "https://www.access-nri.org.au"
     git = "https://github.com/ACCESS-NRI/cice4.git"
@@ -18,8 +18,8 @@ class Cice4(MakefilePackage):
     maintainers("penguian")
     license("BSD-3-Clause", checked_by="anton-seaice")
 
-    version("stable", branch="access-esm1.5", preferred=True)
-    version("2025.04.001", tag="access-esm1.5-2025.04.001", commit="694a9fbd4ac29dc841b38aff002eb36da5b650f1")
+    version("stable", branch="access-esm1.5", deprecated=True, preferred=True)
+    version("2025.04.001", tag="access-esm1.5-2025.04.001", commit="694a9fbd4ac29dc841b38aff002eb36da5b650f1", deprecated=True)
 
     # Support -fuse-ld=lld
     # https://github.com/ACCESS-NRI/spack-packages/issues/255

--- a/spack_repo/access/nri/packages/cice5/package.py
+++ b/spack_repo/access/nri/packages/cice5/package.py
@@ -52,18 +52,6 @@ class Cice5(CMakePackage):
         description="Which model this build is coupled with"
     )
 
-    conflicts(
-        "model=access-esm1.6",
-        when="@access-om2",
-        msg="model=access-esm1.6 not included in @access-om2"
-    )
-
-    conflicts(
-        "model=access-om2",
-        when="@access-esm1.6",
-        msg="model=access-om2 not included in @access-esm1.6"
-    )
-
     variant("deterministic", default=False, sticky=True, description="Deterministic build.")
 
     variant("io_type", default="NetCDF", sticky=True, values=("NetCDF", "PIO"), description="CICE IO Method")

--- a/spack_repo/access/nri/packages/gcom4/package.py
+++ b/spack_repo/access/nri/packages/gcom4/package.py
@@ -23,17 +23,40 @@ class Gcom4(Package):
     maintainers("penguian")
 
     version("stable", branch="access-esm1.6", preferred=True)
-    version("access-esm1.5", branch="access-esm1.5")
+    version(
+        "2025.08.000",
+        tag="2025.08.000",
+        commit="d401980e663267be2a039dbb06bf684e2641ee3d"
+    )
+    version(
+        "2024.05.28",
+        tag="2024.05.28",
+        commit="e123dea738209ab10e194a10e2f19017aac2b032"
+    )
+    version(
+        "2024.05.22",
+        tag="2024.05.22",
+        commit="1ff765f12ff2413b85bdc18a4bdecd152cfcf1f1"
+    )
+    version(
+        "2024.05.21",
+        tag="2024.05.21",
+        commit="5c50f725145636862f9e82854244c25bd1d5fe9a"
+    )
 
     variant("mpi", default=True, sticky=True, description="Build with MPI")
+
+    conflicts(
+        "@access-esm1.5",
+        msg="access-esm1.5 is only available in access-spack-packages versions older than 2026.08.000."
+    )
+    conflicts("%gcc", msg="gcom4 cannot be compiled with gcc, at the moment")
 
     depends_on("c", type="build")
     depends_on("fortran", type="build")
 
     depends_on("fcm", type="build")
     depends_on("mpi", when="+mpi")
-
-    conflicts("%gcc")
 
     def gcom_machine(self, spec):
         """

--- a/spack_repo/access/nri/packages/libaccessom2/package.py
+++ b/spack_repo/access/nri/packages/libaccessom2/package.py
@@ -16,7 +16,12 @@ class Libaccessom2(CMakePackage):
 
     maintainers("harshula")
 
-    version("access-om2", branch="master", preferred=True)
+    version("stable", branch="master", preferred=True)
+    version(
+        "2026.02.000",
+        tag="2026.02.000",
+        commit="6fbf94ce77f69a1d37af536cc45aeedee47556a5"
+    )
 
     variant("deterministic", default=False, sticky=True, description="Deterministic build.")
     variant("optimisation_report", default=False, sticky=True, description="Generate optimisation reports.")

--- a/spack_repo/access/nri/packages/mom5/package.py
+++ b/spack_repo/access/nri/packages/mom5/package.py
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.version.version_types import GitVersion, StandardVersion
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack.package import *
 
@@ -20,50 +19,43 @@ class Mom5(CMakePackage):
     # https://github.com/ACCESS-NRI/MOM5#LGPL-3.0-1-ov-file
     license("LGPL-3.0-only", checked_by="dougiesquire")
 
-    version("mom_solo", branch="master")
-    version("mom_sis", branch="master")
-    version("access-om2", branch="master", preferred=True)
-    version("legacy-access-om2-bgc", branch="master")
-    version("access-esm1.5", branch="access-esm1.5")
-    version("access-esm1.6", branch="master")
-
-    depends_on("c", type="build")
-    depends_on("fortran", type="build")
-    depends_on("cmake@3.18:", type="build")
-
-    # NOTE: @mom matches both mom_solo and mom_sis
-    build_system(
-        conditional("cmake", when="@mom,access-om2,legacy-access-om2-bgc,access-esm1.6"),
-        default="cmake",
+    version("stable", branch="master", preferred=True)
+    version(
+        "2026.02.001",
+        tag="2026.02.001",
+        commit="56261d353c3803e075408ed8421e8c7bf1802887"
+    )
+    version(
+        "2026.02.000",
+        tag="2026.02.000",
+        commit="995fe497e1b91342f465cbed66eaa1336f183ec0"
+    )
+    version(
+        "2025.08.000",
+        tag="2025.08.000",
+        commit="627a321f7490afc69b4a8e777992bcfb1f58b5ae"
+    )
+    version(
+        "2025.05.000",
+        tag="2025.05.000",
+        commit="9f575d8532579a0f717002c571e68037e79c7396"
     )
 
-    with when("@mom,access-om2,legacy-access-om2-bgc,access-esm1.6"):
-        depends_on("netcdf-c@4.7.4:")
-        depends_on("netcdf-fortran@4.5.2:")
-        # Depend on virtual package "mpi".
-        depends_on("mpi")
+    _types = {
+        "mom_solo": "MOM5_SOLO",
+        "mom_sis": "MOM5_SIS",
+        "access-om2": "MOM5_ACCESS_OM",
+        "access-esm1.6": "MOM5_ACCESS_ESM",
+        "access-om2-legacy-bgc": "MOM5_ACCESS_OM_BGC"
+    }
 
-    with when("@access-om2,legacy-access-om2-bgc"):
-        depends_on("datetime-fortran")
-        depends_on("libaccessom2+deterministic", when="+deterministic")
-        depends_on("libaccessom2~deterministic", when="~deterministic")
-
-    with when("@access-om2,legacy-access-om2-bgc,access-esm1.6"):
-        depends_on("oasis3-mct+deterministic", when="+deterministic")
-        depends_on("oasis3-mct~deterministic", when="~deterministic")
-
-    # NOTE: Spack will also match "access-om2-legacy-bgc" here, that's why
-    #       it has been renamed to "legacy-access-om2-bgc".
-    with when("@access-om2,access-esm1.6"):
-        depends_on("access-fms")
-        depends_on("access-generic-tracers")
-
-    # legacy-access-om2-bgc builds with access-generic-tracers but it
-    # is not configured for use in ACCESS-OM2-BGC configurations.
-    with when("@legacy-access-om2-bgc"):
-        depends_on("access-fms")
-        depends_on("access-generic-tracers")
-
+    variant(
+        "model",
+        default="access-om2",
+        sticky=True,
+        description="MOM5 build type",
+        values=tuple(_types.keys())
+    )
     variant(
         "build_type",
         default="RelWithDebInfo",
@@ -78,52 +70,43 @@ class Mom5(CMakePackage):
         description="Deterministic build"
     )
 
-    with when("@access-esm1.5"):
-        depends_on("netcdf-c@4.7.1:")
-        depends_on("netcdf-fortran@4.5.1:")
-        depends_on("openmpi")
-        depends_on("oasis3-mct@access-esm1.5")
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
+    depends_on("cmake@3.18:", type="build")
 
-    root_cmakelists_dir = "cmake/"
+    # Depend on virtual package "mpi".
+    depends_on("mpi")
+    depends_on("netcdf-c@4.7.4:")
+    depends_on("netcdf-fortran@4.5.2:")
 
-    phases = ("setup", "cmake", "build", "install")
+    for _m in ("access-om2", "access-om2-legacy-bgc"):
+        with when(f"model={_m}"):
+            depends_on("datetime-fortran")
+            depends_on("libaccessom2+deterministic", when="+deterministic")
+            depends_on("libaccessom2~deterministic", when="~deterministic")
 
-    # NOTE: The keys in the __builds variable are required to check whether
-    #       a valid version was passed in by the user.
-    __builds = {
-        "mom_solo": "MOM5_SOLO",
-        "mom_sis": "MOM5_SIS",
-        "access-om2": "MOM5_ACCESS_OM",
-        "access-esm1.6": "MOM5_ACCESS_ESM",
-        "legacy-access-om2-bgc": "MOM5_ACCESS_OM_BGC"
-    }
-    __version = "INVALID"
+    # access-om2-legacy-bgc builds with access-generic-tracers but it
+    # is not configured for use in ACCESS-OM2-BGC configurations.
+    for _m in ("access-om2", "access-esm1.6", "access-om2-legacy-bgc"):
+        with when(f"model={_m}"):
+            depends_on("oasis3-mct+deterministic", when="+deterministic")
+            depends_on("oasis3-mct~deterministic", when="~deterministic")
+            depends_on("access-fms")
+            depends_on("access-generic-tracers")
 
-    # NOTE: This functionality will hopefully be implemented in the Spack core
-    #       in the future. Till then, this approach can be used in other SPRs
-    #       where this functionality is required.
-    def setup(self, spec, prefix):
-        if isinstance(spec.version, GitVersion):
-            self.__version = spec.version.ref_version.string
-        elif isinstance(spec.version, StandardVersion):
-            self.__version = spec.version.string
-        else:
-            raise ValueError("version=" + spec.version.string)
+    for _m in ("access-esm1.5", "legacy-access-om2-bgc") + tuple(_types.keys()):
+        conflicts(
+            f"@{_m}",
+            msg=f"Version @{_m} is only available in access-spack-packages versions older than 2026.08.000. Use variant 'model' instead."
+        )
 
-        # The rest of the checks are only required if a __builds member
-        # variable exists
-        if self.__version not in self.__builds.keys():
-            raise ValueError(
-                f"CMakeBuilder doesn't support version {self.__version}. The version must "
-                "be selected from: " + ", ".join(self.__builds.keys())
-            )
+    del _m
 
-        print("INFO: version=" + self.__version +
-                " type=" + self.__builds[self.__version])
+    root_cmakelists_dir = "cmake"
 
     def cmake_args(self):
         args = [
-            self.define("MOM5_TYPE", self.__builds[self.__version]),
+            self.define("MOM5_TYPE", self._types[self.spec.variants["model"].value]),
             self.define_from_variant("MOM5_DETERMINISTIC", "deterministic"),
         ]
         return args

--- a/spack_repo/access/nri/packages/mom5/package.py
+++ b/spack_repo/access/nri/packages/mom5/package.py
@@ -4,20 +4,18 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack_repo.builtin.build_systems import cmake, makefile
 from spack.version.version_types import GitVersion, StandardVersion
 from spack_repo.builtin.build_systems.cmake import CMakePackage
-from spack_repo.builtin.build_systems.makefile import MakefilePackage
 from spack.package import *
 
 
-class Mom5(CMakePackage, MakefilePackage):
+class Mom5(CMakePackage):
     """MOM is a numerical ocean model based on the hydrostatic primitive equations."""
 
     homepage = "https://www.access-nri.org.au"
     git = "https://github.com/ACCESS-NRI/mom5.git"
 
-    maintainers("dougiesquire", "harshula", "penguian")
+    maintainers("dougiesquire", "harshula")
 
     # https://github.com/ACCESS-NRI/MOM5#LGPL-3.0-1-ov-file
     license("LGPL-3.0-only", checked_by="dougiesquire")
@@ -31,39 +29,13 @@ class Mom5(CMakePackage, MakefilePackage):
 
     depends_on("c", type="build")
     depends_on("fortran", type="build")
+    depends_on("cmake@3.18:", type="build")
 
     # NOTE: @mom matches both mom_solo and mom_sis
     build_system(
-        conditional("makefile", when="@access-om2,legacy-access-om2-bgc,access-esm1.5"),
         conditional("cmake", when="@mom,access-om2,legacy-access-om2-bgc,access-esm1.6"),
         default="cmake",
     )
-
-    with when("build_system=cmake"):
-        depends_on("cmake@3.18:", type="build")
-        variant("build_type", default="RelWithDebInfo",
-            sticky=True,
-            description="CMake build type",
-            values=("Debug", "Release", "RelWithDebInfo")
-        )
-        variant("deterministic", default=False, sticky=True, description="Deterministic build")
-
-    with when("build_system=makefile"):
-        variant("restart_repro", default=True, sticky=True, description="Reproducible restart build.")
-        variant(
-            "deterministic",
-            default=False,
-            sticky=True,
-            description="Deterministic build",
-            when="@access-om2,legacy-access-om2-bgc"
-        )
-        variant(
-            "optimisation_report",
-            default=False,
-            sticky=True,
-            description="Generate optimisation reports",
-            when="@access-om2,legacy-access-om2-bgc"
-        )
 
     with when("@mom,access-om2,legacy-access-om2-bgc,access-esm1.6"):
         depends_on("netcdf-c@4.7.4:")
@@ -89,8 +61,22 @@ class Mom5(CMakePackage, MakefilePackage):
     # legacy-access-om2-bgc builds with access-generic-tracers but it
     # is not configured for use in ACCESS-OM2-BGC configurations.
     with when("@legacy-access-om2-bgc"):
-        depends_on("access-fms", when="build_system=cmake")
-        depends_on("access-generic-tracers", when="build_system=cmake")
+        depends_on("access-fms")
+        depends_on("access-generic-tracers")
+
+    variant(
+        "build_type",
+        default="RelWithDebInfo",
+        sticky=True,
+        description="CMake build type",
+        values=("Debug", "Release", "RelWithDebInfo")
+    )
+    variant(
+        "deterministic",
+        default=False,
+        sticky=True,
+        description="Deterministic build"
+    )
 
     with when("@access-esm1.5"):
         depends_on("netcdf-c@4.7.1:")
@@ -98,8 +84,6 @@ class Mom5(CMakePackage, MakefilePackage):
         depends_on("openmpi")
         depends_on("oasis3-mct@access-esm1.5")
 
-
-class CMakeBuilder(cmake.CMakeBuilder):
     root_cmakelists_dir = "cmake/"
 
     phases = ("setup", "cmake", "build", "install")
@@ -118,13 +102,13 @@ class CMakeBuilder(cmake.CMakeBuilder):
     # NOTE: This functionality will hopefully be implemented in the Spack core
     #       in the future. Till then, this approach can be used in other SPRs
     #       where this functionality is required.
-    def setup(self, pkg, spec, prefix):
-        if isinstance(pkg.version, GitVersion):
-            self.__version = pkg.version.ref_version.string
-        elif isinstance(pkg.version, StandardVersion):
-            self.__version = pkg.version.string
+    def setup(self, spec, prefix):
+        if isinstance(spec.version, GitVersion):
+            self.__version = spec.version.ref_version.string
+        elif isinstance(spec.version, StandardVersion):
+            self.__version = spec.version.string
         else:
-            raise ValueError("version=" + pkg.version.string)
+            raise ValueError("version=" + spec.version.string)
 
         # The rest of the checks are only required if a __builds member
         # variable exists
@@ -143,513 +127,3 @@ class CMakeBuilder(cmake.CMakeBuilder):
             self.define_from_variant("MOM5_DETERMINISTIC", "deterministic"),
         ]
         return args
-
-
-class MakefileBuilder(makefile.MakefileBuilder):
-    phases = ("setup", "edit", "build", "install")
-
-    __builds = {
-        "access-om2": "ACCESS-OM",
-        "legacy-access-om2-bgc": "ACCESS-OM-BGC",
-        "access-esm1.5": "ACCESS-CM"
-    }
-    __version = "INVALID"
-    __platform = "spack"
-
-    # NOTE: This functionality will hopefully be implemented in the Spack core
-    #       in the future. Till then, this approach can be used in other SPRs
-    #       where this functionality is required.
-    def setup(self, pkg, spec, prefix):
-        if isinstance(pkg.version, GitVersion):
-            self.__version = pkg.version.ref_version.string
-        elif isinstance(pkg.version, StandardVersion):
-            self.__version = pkg.version.string
-        else:
-            raise ValueError("version=" + pkg.version.string)
-
-        # The rest of the checks are only required if a __builds member
-        # variable exists
-        if self.__version not in self.__builds.keys():
-            raise ValueError(
-                f"MakefileBuilder doesn't support version {self.__version}. The version must "
-                "be selected from: " + ", ".join(self.__builds.keys())
-            )
-
-        print("INFO: version=" + self.__version +
-                " type=" + self.__builds[self.__version])
-
-    def edit(self, pkg, spec, prefix):
-
-        srcdir = pkg.stage.source_path
-        makeinc_path = join_path(srcdir, "bin", "mkmf.template.spack")
-        config = {}
-
-        # NOTE: The order of the libraries matters during the linking step!
-        if self.__version == "access-esm1.5":
-            istr = " ".join([
-                    join_path((spec["oasis3-mct"].headers).cpp_flags, "psmile.MPI1"),
-                    join_path((spec["oasis3-mct"].headers).cpp_flags, "mct")])
-            ideps = ["netcdf-fortran"]
-            ldeps = ["oasis3-mct", "netcdf-c", "netcdf-fortran"]
-            FFLAGS_OPT = "-O3 -debug minimal -xCORE-AVX512 -align array64byte"
-            CFLAGS_OPT = "-O2 -debug minimal -no-vec"
-        else:
-            istr = join_path((spec["oasis3-mct"].headers).cpp_flags, "psmile.MPI1")
-            ideps = ["oasis3-mct", "libaccessom2", "netcdf-fortran"]
-            # NOTE: datetime-fortran is a dependency of libaccessom2.
-            ldeps = ["oasis3-mct", "libaccessom2", "netcdf-c", "netcdf-fortran", "datetime-fortran"]
-
-            # TODO: https://github.com/ACCESS-NRI/ACCESS-OM/issues/12
-            FFLAGS_OPT = "-g3 -O2 -xCORE-AVX2 -debug all -check none -traceback"
-            CFLAGS_OPT = "-O2 -debug minimal -xCORE-AVX2"
-            if self.spec.satisfies("+deterministic"):
-                FFLAGS_OPT = "-g0 -O0 -xCORE-AVX2 -debug none -check none"
-                CFLAGS_OPT = "-O0 -debug none -xCORE-AVX2"
-                print("INFO: +deterministic applied")
-
-        incs = " ".join([istr] + [(spec[d].headers).cpp_flags for d in ideps])
-        libs = " ".join([(spec[d].libs).ld_flags for d in ldeps])
-
-        # Copied from bin/mkmf.template.ubuntu
-        config["gcc"] = f"""
-FC = mpifort
-CC = gcc
-LD = $(FC)
-#########
-# flags #
-#########
-DEBUG =
-REPRO =
-VERBOSE =
-OPENMP =
-
-MAKEFLAGS += --jobs=$(shell grep '^processor' /proc/cpuinfo | wc -l)
-
-FPPFLAGS := 
-
-FFLAGS := -fcray-pointer -fdefault-real-8 -ffree-line-length-none -fno-range-check -Waliasing -Wampersand -Warray-bounds -Wcharacter-truncation -Wconversion -Wline-truncation -Wintrinsics-std -Wsurprising -Wno-tabs -Wunderflow -Wunused-parameter -Wintrinsic-shadow -Wno-align-commons -fallow-argument-mismatch -fallow-invalid-boz
-FFLAGS += {incs}
-FFLAGS += -DGFORTRAN
-
-#
-FFLAGS_OPT = -O2
-FFLAGS_REPRO = 
-FFLAGS_DEBUG = -O0 -g -W -fbounds-check 
-FFLAGS_OPENMP = -fopenmp
-FFLAGS_VERBOSE = 
-
-CFLAGS := -D__IFC {incs}
-CFLAGS += $(shell nc-config --cflags)
-CFLAGS_OPT = -O2
-CFLAGS_OPENMP = -fopenmp
-CFLAGS_DEBUG = -O0 -g 
-
-# Optional Testing compile flags.  Mutually exclusive from DEBUG, REPRO, and OPT
-# *_TEST will match the production if no new option(s) is(are) to be tested.
-FFLAGS_TEST = -O2
-CFLAGS_TEST = -O2
-
-LDFLAGS :=
-LDFLAGS_OPENMP := -fopenmp
-LDFLAGS_VERBOSE := 
-
-ifneq ($(REPRO),)
-CFLAGS += $(CFLAGS_REPRO)
-FFLAGS += $(FFLAGS_REPRO)
-endif
-ifneq ($(DEBUG),)
-CFLAGS += $(CFLAGS_DEBUG)
-FFLAGS += $(FFLAGS_DEBUG)
-else ifneq ($(TEST),)
-CFLAGS += $(CFLAGS_TEST)
-FFLAGS += $(FFLAGS_TEST)
-else
-CFLAGS += $(CFLAGS_OPT)
-FFLAGS += $(FFLAGS_OPT)
-endif
-
-ifneq ($(OPENMP),)
-CFLAGS += $(CFLAGS_OPENMP)
-FFLAGS += $(FFLAGS_OPENMP)
-LDFLAGS += $(LDFLAGS_OPENMP)
-endif
-
-ifneq ($(VERBOSE),)
-CFLAGS += $(CFLAGS_VERBOSE)
-FFLAGS += $(FFLAGS_VERBOSE)
-LDFLAGS += $(LDFLAGS_VERBOSE)
-endif
-
-ifeq ($(NETCDF),3)
-  # add the use_LARGEFILE cppdef
-  ifneq ($(findstring -Duse_netCDF,$(CPPDEFS)),)
-    CPPDEFS += -Duse_LARGEFILE
-  endif
-endif
-
-LIBS := {libs}
-LDFLAGS += $(LIBS)
-"""
-
-        # Copied from bin/mkmf.template.nci
-        if self.__version == "access-esm1.5":
-            config["intel"] = f"""
-ifeq ($(VTRACE), yes)
-    FC = mpifort-vt
-    LD = mpifort-vt
-else
-    FC = mpifort
-    LD = mpifort
-endif
-
-CC = mpicc
-
-REPRO =
-VERBOSE =
-OPT = on
-
-MAKEFLAGS += --jobs=4
-
-INCLUDE = {incs}
-
-FPPFLAGS := -fpp -Wp,-w $(INCLUDE)
-FFLAGS := -fno-alias -safe-cray-ptr -fpe0 -ftz -assume byterecl -i4 -r8 -traceback -nowarn -check noarg_temp_created -assume buffered_io -convert big_endian
-FFLAGS_OPT = {FFLAGS_OPT}
-FFLAGS_DEBUG = -g -O0 -debug all -check -check noarg_temp_created -check nopointer -warn -warn noerrors -ftrapuv
-FFLAGS_REPRO = -O2 -debug minimal -no-vec -fp-model precise
-FFLAGS_VERBOSE = -v -V -what
-
-CFLAGS := -D__IFC $(INCLUDE)
-CFLAGS_OPT = {CFLAGS_OPT}
-CFLAGS_DEBUG = -O0 -g -ftrapuv -traceback
-
-LDFLAGS :=
-LDFLAGS_VERBOSE := -Wl,-V,--verbose,-cref,-M
-
-ifneq ($(REPRO),)
-CFLAGS += $(CFLAGS_REPRO)
-FFLAGS += $(FFLAGS_REPRO)
-endif
-
-ifneq ($(DEBUG),)
-CFLAGS += $(CFLAGS_DEBUG)
-FFLAGS += $(FFLAGS_DEBUG)
-else
-CFLAGS += $(CFLAGS_OPT)
-FFLAGS += $(FFLAGS_OPT)
-endif
-
-ifneq ($(VERBOSE),)
-CFLAGS += $(CFLAGS_VERBOSE)
-FFLAGS += $(FFLAGS_VERBOSE)
-LDFLAGS += $(LDFLAGS_VERBOSE)
-endif
-
-LIBS := {libs}
-
-LDFLAGS += $(LIBS)
-"""
-        else:
-            config["intel"] = f"""
-ifeq ($(VTRACE), yes)
-    FC := mpifort-vt
-    LD := mpifort-vt
-else
-    FC := mpifort
-    LD := mpifort
-endif
-
-CC := mpicc
-
-VERBOSE :=
-OPT := on
-
-MAKEFLAGS += -j
-
-INCLUDE   := {incs}
-
-FPPFLAGS := -fpp -Wp,-w $(INCLUDE)
-FFLAGS := -fno-alias -safe-cray-ptr -fpe0 -ftz -assume byterecl -i4 -r8 -nowarn -check noarg_temp_created -assume nobuffered_io -convert big_endian -grecord-gcc-switches -align all
-FFLAGS_OPT := {FFLAGS_OPT}
-FFLAGS_REPORT := -qopt-report=5 -qopt-report-annotate
-FFLAGS_DEBUG := -g3 -O0 -debug all -check -check noarg_temp_created -check nopointer -warn -warn noerrors -ftrapuv -traceback
-FFLAGS_REPRO := -fp-model precise -fp-model source -align all
-FFLAGS_VERBOSE := -v -V -what
-
-CFLAGS := -D__IFC $(INCLUDE)
-CFLAGS_OPT := {CFLAGS_OPT}
-CFLAGS_REPORT := -qopt-report=5 -qopt-report-annotate
-CFLAGS_DEBUG := -O0 -g -ftrapuv -traceback
-CFLAGS_REPRO := -fp-model precise -fp-model source
-
-LDFLAGS :=
-LDFLAGS_VERBOSE := -Wl,-V,--verbose,-cref,-M
-
-ifneq ($(REPRO),)
-CFLAGS += $(CFLAGS_REPRO)
-FFLAGS += $(FFLAGS_REPRO)
-endif
-
-ifneq ($(DEBUG),)
-CFLAGS += $(CFLAGS_DEBUG)
-FFLAGS += $(FFLAGS_DEBUG)
-else
-CFLAGS += $(CFLAGS_OPT)
-FFLAGS += $(FFLAGS_OPT)
-endif
-
-ifneq ($(VERBOSE),)
-CFLAGS += $(CFLAGS_VERBOSE)
-FFLAGS += $(FFLAGS_VERBOSE)
-LDFLAGS += $(LDFLAGS_VERBOSE)
-endif
-
-ifneq ($(REPORT),)
-CFLAGS += $(CFLAGS_REPORT)
-FFLAGS += $(FFLAGS_REPORT)
-endif
-
-LIBS := {libs}
-
-ifneq ($(OASIS_ROOT),)
-LIBS += -L$(OASIS_ROOT)/Linux/lib -lpsmile.MPI1 -lmct -lmpeu -lscrip
-endif
-
-ifneq ($(LIBACCESSOM2_ROOT),)
-LIBS += -L$(LIBACCESSOM2_ROOT)/build/lib -laccessom2
-endif
-
-LDFLAGS += $(LIBS)
-"""
-
-        # Add support for the ifx compiler
-        # TODO: `.replace() is a temporary workaround for:
-        # icx: error: unsupported argument 'source' to option '-ffp-model='
-        # The `.replace()` apparently doesn't modify the object.
-        config["oneapi"] = config["intel"].replace("CFLAGS_REPRO := -fp-model precise -fp-model source", "CFLAGS_REPRO := -fp-model precise")
-        # Add support for Spack v1.0
-        config["intel-oneapi-compilers"] = config["oneapi"]
-        config["intel-oneapi-compilers-classic"] = config["oneapi"]
-
-        if self.__version == "access-esm1.5":
-            config["post"] = """
-# you should never need to change any lines below.
-
-# see the MIPSPro F90 manual for more details on some of the file extensions
-# discussed here.
-# this makefile template recognizes fortran sourcefiles with extensions
-# .f, .f90, .F, .F90. Given a sourcefile <file>.<ext>, where <ext> is one of
-# the above, this provides a number of default actions:
-
-# make <file>.opt	create an optimization report
-# make <file>.o		create an object file
-# make <file>.s		create an assembly listing
-# make <file>.x		create an executable file, assuming standalone
-#			source
-# make <file>.i		create a preprocessed file (for .F)
-# make <file>.i90	create a preprocessed file (for .F90)
-
-# The macro TMPFILES is provided to slate files like the above for removal.
-
-RM = rm -f
-SHELL = /bin/csh -f
-TMPFILES = .*.m *.B *.L *.i *.i90 *.l *.s *.mod *.opt
-
-.SUFFIXES: .F .F90 .H .L .T .f .f90 .h .i .i90 .l .o .s .opt .x
-
-.f.L:
-	$(FC) $(FFLAGS) -c -listing $*.f
-.f.opt:
-	$(FC) $(FFLAGS) -c -opt_report_level max -opt_report_phase all -opt_report_file $*.opt $*.f
-.f.l:
-	$(FC) $(FFLAGS) -c $(LIST) $*.f
-.f.T:
-	$(FC) $(FFLAGS) -c -cif $*.f
-.f.o:
-	$(FC) $(FFLAGS) -c $*.f
-.f.s:
-	$(FC) $(FFLAGS) -S $*.f
-.f.x:
-	$(FC) $(FFLAGS) -o $*.x $*.f *.o $(LDFLAGS)
-.f90.L:
-	$(FC) $(FFLAGS) -c -listing $*.f90
-.f90.opt:
-	$(FC) $(FFLAGS) -c -opt_report_level max -opt_report_phase all -opt_report_file $*.opt $*.f90
-.f90.l:
-	$(FC) $(FFLAGS) -c $(LIST) $*.f90
-.f90.T:
-	$(FC) $(FFLAGS) -c -cif $*.f90
-.f90.o:
-	$(FC) $(FFLAGS) -c $*.f90
-.f90.s:
-	$(FC) $(FFLAGS) -c -S $*.f90
-.f90.x:
-	$(FC) $(FFLAGS) -o $*.x $*.f90 *.o $(LDFLAGS)
-.F.L:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -listing $*.F
-.F.opt:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -opt_report_level max -opt_report_phase all -opt_report_file $*.opt $*.F
-.F.l:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c $(LIST) $*.F
-.F.T:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -cif $*.F
-.F.f:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) -EP $*.F > $*.f
-.F.i:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) -P $*.F
-.F.o:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c $*.F
-.F.s:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -S $*.F
-.F.x:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -o $*.x $*.F *.o $(LDFLAGS)
-.F90.L:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -listing $*.F90
-.F90.opt:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -opt_report_level max -opt_report_phase all -opt_report_file $*.opt $*.F90
-.F90.l:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c $(LIST) $*.F90
-.F90.T:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -cif $*.F90
-.F90.f90:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) -EP $*.F90 > $*.f90
-.F90.i90:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) -P $*.F90
-.F90.o:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c $*.F90
-.F90.s:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -c -S $*.F90
-.F90.x:
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) -o $*.x $*.F90 *.o $(LDFLAGS)
-"""
-        else:
-            # Copied from bin/mkmf.template.t90
-            # TODO: Why from `mkmf.template.t90`? Copy bin/mkmf.template.nci.
-            config["post"] = """
-# you should never need to change any lines below.
-
-# see the CF90 manual for more details on some of the file extensions
-# discussed here.
-# this makefile template recognizes fortran sourcefiles with extensions
-# .f, .f90, .F, .F90. Given a sourcefile <file>.<ext>, where <ext> is one of
-# the above, this provides a number of default actions:
-
-# make <file>.T		create a CIF file
-# make <file>.lst	create a compiler listing
-# make <file>.o		create an object file
-# make <file>.s		create an assembly listing
-# make <file>.x		create an executable file, assuming standalone
-#			source
-
-# make <file>.i		create a preprocessed file (only for .F and .F90
-#			extensions)
-
-# make <file>.hpm	produce hpm output from <file>.x
-# make <file>.proc	produce procstat output from <file>.x
-
-# The macro TMPFILES is provided to slate files like the above for removal.
-
-RM = rm -f
-SHELL = /bin/csh
-TMPFILES = .*.m *.T *.TT *.hpm *.i *.lst *.proc *.s
-
-.SUFFIXES: .F .F90 .H .T .f .F90 .h .hpm .i .lst .proc .o .s .x
-
-.f.T:
-	$(FC) $(FFLAGS) -c -Ca $*.f
-.f.lst:
-	$(FC) $(FFLAGS) $(LIST) -c $*.f
-.f.o:
-	$(FC) $(FFLAGS) -c     $*.f
-.f.s:
-	$(FC) $(FFLAGS) -eS    $*.f
-.f.x:
-	$(FC) $(FFLAGS) $(LDFLAGS) -o $*.x $*.f
-.f90.T:
-	$(FC) $(FFLAGS) -c -Ca $*.f90
-.f90.lst:
-	$(FC) $(FFLAGS) $(LIST) -c $*.f90
-.f90.o:
-	$(FC) $(FFLAGS) -c     $*.f90
-.f90.s:
-	$(FC) $(FFLAGS) -c -eS $*.f90
-.f90.x:
-	$(FC) $(FFLAGS) $(LDFLAGS) -o $*.x $*.f90
-.F.T:
-	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FFLAGS) -c -Ca $*.F
-.F.i:
-	$(FC) $(CPPDEFS) $(CPPFLAGS) -eP $*.F
-.F.lst:
-	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FFLAGS) $(LIST) -c $*.F
-.F.o:
-	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FFLAGS) -c     $*.F
-.F.s:
-	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FFLAGS) -c -eS $*.F
-.F.x:
-	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FFLAGS) $(LDFLAGS) -o $*.x $*.F
-.F90.T:
-	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FFLAGS) -c -Ca $*.F90
-.F90.i:
-	$(FC) $(CPPDEFS) $(CPPFLAGS) -eP $*.F90
-.F90.lst:
-	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FFLAGS) $(LIST) -c $*.F90
-.F90.o:
-	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FFLAGS) -c     $*.F90
-.F90.s:
-	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FFLAGS) -c -eS $*.F90
-.F90.x:
-	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FFLAGS) $(LDFLAGS) -o $*.x $*.F90
-.x.proc:
-	procstat -R $*.proc $*.x
-.x.hpm:
-	hpm -r -o $*.hpm $*.x
-"""
-
-        fullconfig = config[pkg.compiler.name] + config["post"]
-        print(fullconfig)
-        with open(makeinc_path, "w") as makeinc:
-            makeinc.write(fullconfig)
-
-    def build(self, pkg, spec, prefix):
-
-        # cd ${ACCESS_OM_DIR}/src/mom/exp
-        # export mom_type=ACCESS-OM
-        # ./MOM_compile.csh --type $mom_type --platform spack
-        with working_dir(join_path(pkg.stage.source_path, "exp")):
-            build = Executable("./MOM_compile.csh")
-
-            if pkg.spec.satisfies("+restart_repro"):
-                build.add_default_env("REPRO", "true")
-                print("INFO: +restart_repro applied")
-
-            if self.__version != "access-esm1.5":
-                # The MOM5 commit d7ba13a3f364ce130b6ad0ba813f01832cada7a2
-                # requires the --no_version switch to avoid git hashes being
-                # embedded in the binary.
-                build.add_default_arg("--no_version")
-                if pkg.spec.satisfies("+optimisation_report"):
-                    build.add_default_env("REPORT", "true")
-                    print("INFO: +optimisation_report applied")
-
-            build(
-                "--type",
-                self.__builds[self.__version],
-                "--platform",
-                self.__platform,
-                "--no_environ"
-            )
-
-    def install(self, pkg, spec, prefix):
-
-        mkdirp(prefix.bin)
-        install(
-            join_path(
-                "exec",
-                self.__platform,
-                self.__builds[self.__version],
-                "fms_" + self.__builds[self.__version] + ".x"
-            ),
-            prefix.bin
-        )
-        install(join_path("bin", "mppnccombine." + self.__platform), prefix.bin)
-

--- a/spack_repo/access/nri/packages/oasis3_mct/package.py
+++ b/spack_repo/access/nri/packages/oasis3_mct/package.py
@@ -25,9 +25,12 @@ class Oasis3Mct(MakefilePackage):
         branch="OASIS3-MCT_5.0",
         git="https://gitlab.com/cerfacs/oasis3-mct.git",
     )
-    # TODO: Remove the "access-om2" once it is no longer being used anywhere
-    version("access-om2", branch="master")
     version("access-esm1.5", branch="access-esm1.5")
+    version(
+        "2025.03.001",
+        tag="2025.03.001",
+        commit="48a76126fc00932e50af19617f3dba7a154717c6"
+    )
 
     variant("deterministic", default=False, sticky=True, description="Deterministic build.")
     variant("optimisation_report", default=False, sticky=True, description="Generate optimisation reports.")
@@ -65,7 +68,7 @@ class Oasis3Mct(MakefilePackage):
     def __create_pkgconfig(self, spec, prefix):
 
         oasis_version = "2.0"
-        if self.spec.satisfies("@upstream,5:"):
+        if self.spec.satisfies("@upstream,5"):
             oasis_version = "5"
 
         mkdirp(self.__pkgdir)

--- a/spack_repo/access/nri/packages/um7/package.py
+++ b/spack_repo/access/nri/packages/um7/package.py
@@ -20,22 +20,39 @@ class Um7(Package):
     homepage = "https://code.metoffice.gov.uk/trac/um"
     git = "https://github.com/ACCESS-NRI/UM7.git"
 
-    # https://code.metoffice.gov.uk/trac/um/wiki/PastReleases
-    version("access-esm1.6", branch="dev-access-esm1.6", preferred=True)
-    version("access-esm1.5", branch="access-esm1.5")
-
-    # Comment to trigger CI for UM7
     maintainers("penguian", "Whyborn")
 
-    depends_on("c", type="build")
-    depends_on("fortran", type="build")
+    # https://code.metoffice.gov.uk/trac/um/wiki/PastReleases
+    version("stable", branch="dev-access-esm1.6", preferred=True)
+    version(
+        "2026.04.000",
+        tag="2026.04.000",
+        commit="06f9a279d092542637342e8d71a70f1a42fd2df8"
+    )
+    version(
+        "2026.02.000",
+        tag="2026.02.000",
+        commit="a1fd578b49602919903a9f68ab06d71e68524369"
+    )
+    version(
+        "2025.12.000",
+        tag="2025.12.000",
+        commit="b5f58fcf8487c177b0d75878bcf015102a90dc7c"
+    )
+    version(
+        "2025.11.000",
+        tag="2025.11.000",
+        commit="e969f21dd521b6c74b4ff4804103e0b297b3ea01"
+    )
+    # This version corresponds to the um7 source code used for ACCESS-ESM1.5
+    version(
+        "2024.10.17",
+        tag="2024.10.17",
+        commit="1d71fe04e003d9df0a2d9318c2ada09a28edef6a"
+    )
 
-    depends_on("fcm", type="build")
-    depends_on("dummygrib", type=("build", "link"))
-    depends_on("gcom4+mpi", type=("build", "link"))
-    depends_on("openmpi", type=("build", "run"))
-    depends_on("netcdf-fortran@4.5.2:", type=("build", "link"))
-    depends_on("oasis3-mct", type=("build", "link"))
+    # https://github.com/ACCESS-NRI/ACCESS-ESM1.6/commit/d07281e7ee53c9233afbe5984339d6659fe1d6cb
+    _VERSION_WITH_CABLE = "@2025.11.000:"
 
     # https://metomi.github.io/fcm/doc/user_guide/build.html
     variant(
@@ -48,8 +65,29 @@ class Um7(Package):
             description="Optimization level",
             values=("high", "debug"), multi=False)
 
-    with when("@access-esm1.6"):
-        depends_on("cable library='access-esm1.6'", type=("build", "link"))
+    conflicts(
+        "@access-esm1.5",
+        msg="access-esm1.5 is only available in access-spack-packages versions older than 2026.08.000."
+    )
+    conflicts(
+        "@access-esm1.6",
+        msg="access-esm1.6 is only available in access-spack-packages versions older than 2026.08.000."
+    )
+
+    depends_on("c", type="build")
+    depends_on("fortran", type="build")
+
+    depends_on("fcm", type="build")
+    depends_on("dummygrib", type=("build", "link"))
+    depends_on("gcom4+mpi", type=("build", "link"))
+    depends_on("openmpi", type=("build", "run"))
+    depends_on("netcdf-fortran@4.5.2:", type=("build", "link"))
+    depends_on("oasis3-mct", type=("build", "link"))
+    depends_on(
+        "cable library='access-esm1.6'",
+        type=("build", "link"),
+        when=_VERSION_WITH_CABLE
+    )
 
     phases = ["edit", "build", "install"]
 
@@ -63,7 +101,7 @@ class Um7(Package):
                 join_path(self.spec["oasis3-mct"].prefix.include, subdir)
                 for subdir in ["psmile.MPI1", "mct"]]
         ideps = ["gcom4", "netcdf-fortran"]
-        if self.spec.satisfies("@access-esm1.6"):
+        if self.spec.satisfies(self._VERSION_WITH_CABLE):
             ideps.append("cable")
         incs = [self.spec[d].prefix.include for d in ideps] + oasis3_incs
         for ipath in incs:
@@ -109,7 +147,7 @@ class Um7(Package):
         """
 
         ldeps = ["oasis3-mct", "netcdf-fortran", "dummygrib"]
-        if self.spec.satisfies("@access-esm1.6"):
+        if self.spec.satisfies(self._VERSION_WITH_CABLE):
             ldeps.append("cable")
         libs = " ".join([self._get_linker_args(spec, d) for d in ldeps] + ["-lgcom"])
 
@@ -158,7 +196,7 @@ class Um7(Package):
         # string for older versions of UM7 which include CABLE as
         # source code.
         CABLE_excl_deps = ""
-        if self.spec.satisfies("@access-esm1.6"):
+        if self.spec.satisfies(self._VERSION_WITH_CABLE):
             CABLE_excl_deps = """
 excl_dep                                           USE::cable_def_types_mod
 excl_dep                                           USE::cbl_masks_mod


### PR DESCRIPTION
### Motivation

* We have an opportunity to remove support for the legacy build systems of access-mocsy and mom5 before the ACCESS-ESM1.6 Release.
* https://github.com/ACCESS-NRI/ACCESS-ESM1.6/issues/180

### Caveat

If we need to backport a bug fix for `gcom4` or `um7` for `ACCESS-ESM1.5`, we could create a new branch `api-v2-esm1.5` that branches off the commit just before the commit containing this PR's merge.

### Pre-merge actions

* Update the `access-spack-packages` tag mentioned in the source files. e.g., "access-esm1.5 is only available in access-spack-packages tagged 2026.07.010 and older."

#### Component Repository CI manifest fixes.

* https://github.com/ACCESS-NRI/MOM5/pull/86
* https://github.com/ACCESS-NRI/libaccessom2/pull/31
* https://github.com/ACCESS-NRI/oasis3-mct/pull/48

### Post-merge actions

* Update: https://github.com/search?q=org%3AACCESS-NRI+%28%3Daccess-om2+OR+%3Daccess-esm1.6%29+NOT+%28model%3Daccess-om2+OR+model%3Daccess-esm1.6%29&type=code
* gcom4/um7 repository CI manifests have to use real versions.
* https://github.com/ACCESS-NRI/ACCESS-OM2/pull/154
* https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/212
* https://github.com/ACCESS-NRI/ACCESS-ESM1.5/pull/51
