### PR TITLE
CICE4: Fix source folder path

### DIFF
--- a/spack_repo/access/nri/packages/cice4/spack-build.sh
+++ b/spack_repo/access/nri/packages/cice4/spack-build.sh
@@ -24,10 +24,9 @@ else
   set debug = $5
 endif
 
-# Location of this model
-setenv SPACKDIR $cwd:h
-setenv SRCDIR $SPACKDIR/spack-src
-setenv CBLD   $SRCDIR/bld
+# Location of the model source folder
+setenv CBLD   `dirname "$0"`
+setenv SRCDIR $CBLD/..
 
 if ($debug == 'debug') then
     setenv DEBUG yes

--- a/spack_repo/access/nri/packages/cice4/spack-build.sh
+++ b/spack_repo/access/nri/packages/cice4/spack-build.sh
@@ -24,9 +24,9 @@ else
   set debug = $5
 endif
 
-# Location of the model source folder
-setenv CBLD   `dirname "$0"`
-setenv SRCDIR $CBLD/..
+# Location of this model
+setenv SRCDIR $cwd
+setenv CBLD   $SRCDIR/bld
 
 if ($debug == 'debug') then
     setenv DEBUG yes


### PR DESCRIPTION
Closes #446 

This changes the source folder in the shell script for the cice4 build to be correct for using spack develop.

This now works correctly with `spack develop`, i.e. can be installed