### PR TITLE
Install build-atmos/bin for access3 UM variant

### DIFF
--- a/spack_repo/access/nri/packages/um/package.py
+++ b/spack_repo/access/nri/packages/um/package.py
@@ -68,10 +68,6 @@ class Um(UmBasePackage):
         When +access3, the package installs libum-atmos.a
         um-recon.exe is always installed.
         """
-
-        # List of executables to install
-        um_exe = ["recon", "atmos"]
-
         if self.spec.variants["access3"].value:
 
             # Create a pkgconf file for the um library
@@ -89,6 +85,9 @@ class Um(UmBasePackage):
         # Install executables and accompanying files into the prefix directory,
         # according to the directory structure of EXEC_DIR, as described in (e.g.)
         # https://code.metoffice.gov.uk/trac/roses-u/browser/b/y/3/9/5/trunk/meta/rose-meta.conf
+
+        # List of executables to install
+        um_exe = ["recon", "atmos"]
         for exe in um_exe:
             bin_dir = join_path(f"build-{exe}", "bin")
             build_bin_dir = join_path(self.build_dir(), bin_dir)

--- a/spack_repo/access/nri/packages/um/package.py
+++ b/spack_repo/access/nri/packages/um/package.py
@@ -69,8 +69,8 @@ class Um(UmBasePackage):
         um-recon.exe is always installed.
         """
 
-        # List of executables to install, always install recon
-        um_exe = ["recon"]
+        # List of executables to install
+        um_exe = ["recon", "atmos"]
 
         if self.spec.variants["access3"].value:
 
@@ -85,9 +85,6 @@ class Um(UmBasePackage):
                 install_dir = join_path(prefix, dir_name)
                 mkdirp(install_dir)
                 install_tree(build_dir, install_dir)
-        else:
-            # Install atmos executable
-            um_exe.append("atmos")
 
         # Install executables and accompanying files into the prefix directory,
         # according to the directory structure of EXEC_DIR, as described in (e.g.)


### PR DESCRIPTION
Closes #448 

This PR modifies the UM spack package to also install the `build-atmos/bin` directory for the `access3` variant. This ensures that the `um-atmos` and `um_script_functions` scripts are installed, which are required for running ACCESS-CM3.