### PR TITLE
Add sticky=True to variants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
       - setup-ci
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 10
       matrix:
         package: ${{ fromJson(needs.setup-ci.outputs.matrix) }}
         exclude:

--- a/spack_repo/access/nri/build_systems/um_base.py
+++ b/spack_repo/access/nri/build_systems/um_base.py
@@ -60,7 +60,7 @@ class UmBasePackage(Package):
         "eccodes",
         "netcdf")
     for var in _bool_variants:
-        variant(var, default=True, description=var)
+        variant(var, default=True, sticky=True, description=var)
 
     # Off/on variants have 3-value "none" "off", "on" logic.
     _off_on_variants = (
@@ -68,7 +68,7 @@ class UmBasePackage(Package):
         "platagnostic",
         "thread_utils")
     for var in _off_on_variants:
-        variant(var, default="none", description=var,
+        variant(var, default="none", sticky=True, description=var,
             values=("none", "off", "on"), multi=False)
 
     # String variants have their default values set to "none" here.
@@ -89,19 +89,31 @@ class UmBasePackage(Package):
         if _project != "um":
             _rev_var = f"{_project}_rev"
             _rev_variants.append(_rev_var)
-            variant(_rev_var, default="none", values="*", multi=False,
+            variant(
+                _rev_var,
+                default="none",
+                sticky=True,
+                values="*",
+                multi=False,
                 description=f"Subversion revision for {_project}. "
-                            f"Defaults to automatic versioning if 'none'.")
+                            f"Defaults to automatic versioning if 'none'."
+            )
 
         # Sources variants
         _sources_var = f"{_project}_sources"
         _sources_variants.append(_sources_var)
-        variant(_sources_var, default="none", values="*", multi=False,
-            description=f"FCM diff extract location of {_project}.")
+        variant(
+            _sources_var,
+            default="none",
+            sticky=True,
+            values="*",
+            multi=False,
+            description=f"FCM diff extract location of {_project}."
+        )
 
         # Git reference variants.
         _ref_var = f"{_project}_ref"
-        variant(_ref_var, default="none", values="*", multi=False,
+        variant(_ref_var, default="none", sticky=True, values="*", multi=False,
             description=f"Git branch/tag/commit for {_project}. "
                         f"Overrides Subversion. "
                         f"Defaults to automatic tagging if 'none'.")
@@ -147,7 +159,14 @@ class UmBasePackage(Package):
     ]
 
     for _var in _other_variants:
-        variant(_var, default="none", values="*", multi=False, description=_var)
+        variant(
+            _var,
+            default="none",
+            sticky=True,
+            values="*",
+            multi=False,
+            description=_var
+        )
 
     depends_on("c", type="build")
     depends_on("fortran", type="build")

--- a/spack_repo/access/nri/packages/access3_share/package.py
+++ b/spack_repo/access/nri/packages/access3_share/package.py
@@ -24,7 +24,7 @@ class Access3Share(CMakePackage):
     for tag, commit in ACCESS3_VERSIONS.items():
         version(tag, tag=tag, commit=commit)
 
-    variant("openmp", default=False, description="Enable OpenMP")
+    variant("openmp", default=False, sticky=True, description="Enable OpenMP")
 
     depends_on("c", type="build")
     depends_on("fortran", type="build")

--- a/spack_repo/access/nri/packages/access_cice/package.py
+++ b/spack_repo/access/nri/packages/access_cice/package.py
@@ -30,17 +30,20 @@ class AccessCice(CMakePackage):
     variant(
         "access3",
         default=True,
+        sticky=True,
         description="Install CICE as library for Access3 models"
     )
 
     variant("io_type", 
         default="NetCDF",
+        sticky=True,
         values=("NetCDF", "PIO", "Binary"),
         description="CICE IO Method"
     )
 
     variant("driver",
             default="none",
+            sticky=True,
             values=("none", "nuopc/cmeps", "access/cmeps", "standalone/cice"),
             description="CICE driver path"
     )

--- a/spack_repo/access/nri/packages/access_cice/package.py
+++ b/spack_repo/access/nri/packages/access_cice/package.py
@@ -26,7 +26,7 @@ class AccessCice(CMakePackage):
     version("CICE6.6.0-3", tag="CICE6.6.0-3", commit="2c444bd9d2fad1f1df4d855debc2801d4b23487d")
     version("CICE6.6.0-1", tag="CICE6.6.0-1", commit="964a4455db3127d0c4681e6533f6d9733a5e8255")
 
-    variant("openmp", default=False, description="Enable OpenMP")
+    variant("openmp", default=False, sticky=True, description="Enable OpenMP")
     variant(
         "access3",
         default=True,

--- a/spack_repo/access/nri/packages/access_esm1p6/package.py
+++ b/spack_repo/access/nri/packages/access_esm1p6/package.py
@@ -31,6 +31,7 @@ class AccessEsm1p6(BundlePackage):
     variant(
         "cice",
         default="5",
+        sticky=True,
         description="(Deprecated) choose the version of the CICE sea-ice model.",
         values=("5"),
         multi=False,
@@ -38,6 +39,7 @@ class AccessEsm1p6(BundlePackage):
     variant(
         "um",
         default="access-esm1.6",
+        sticky=True,
         description="Choose the branch of um7.",
         values=("access-esm1.5", "access-esm1.6"),
         multi=False,

--- a/spack_repo/access/nri/packages/access_fms/package.py
+++ b/spack_repo/access/nri/packages/access_fms/package.py
@@ -26,15 +26,16 @@ class AccessFms(CMakePackage):
     version("main", branch="main")
     version("mom5", branch="mom5", preferred=True)
 
-    variant("gfs_phys", default=False, description="Use GFS Physics")
-    variant("large_file", default=False, description="Enable compiler definition -Duse_LARGEFILE.")
+    variant("gfs_phys", default=False, sticky=True, description="Use GFS Physics")
+    variant("large_file", default=False, sticky=True, description="Enable compiler definition -Duse_LARGEFILE.")
     variant(
         "internal_file_nml",
         default=True,
+        sticky=True,
         description="Enable compiler definition -DINTERNAL_FILE_NML.",
     )
-    variant("pic", default=False, description="Build with position independent code")
-    variant("shared", default=False, description="Build shared/dynamic libraries")
+    variant("pic", default=False, sticky=True, description="Build with position independent code")
+    variant("shared", default=False, sticky=True, description="Build shared/dynamic libraries")
     # To build a shared/dynamic library, both `pic` and `shared` are required:
     requires("+pic", when="+shared", msg="The +shared variant requires +pic")
 

--- a/spack_repo/access/nri/packages/access_generic_tracers/package.py
+++ b/spack_repo/access/nri/packages/access_generic_tracers/package.py
@@ -38,6 +38,7 @@ class AccessGenericTracers(CMakePackage):
     variant(
         "shared",
         default=False,
+        sticky=True,
         description="Build shared/dynamic libraries"
     )
     # NOTE: access-fms@mom5 should be used in OM2, ESM1.5 and ESM1.6 to preserve
@@ -45,6 +46,7 @@ class AccessGenericTracers(CMakePackage):
     variant(
         "use_access_fms",
         default=True,
+        sticky=True,
         description="If True, depend on access-fms, otherwise depend on fms"
     )
 

--- a/spack_repo/access/nri/packages/access_mocsy/package.py
+++ b/spack_repo/access/nri/packages/access_mocsy/package.py
@@ -34,18 +34,21 @@ class AccessMocsy(CMakePackage):
     variant(
         "shared",
         default=False,
+        sticky=True,
         description="Build shared/dynamic libraries",
         when="@2025.07.002:",
     )
     variant(
         "build_type",
         default="RelWithDebInfo",
+        sticky=True,
         description="CMake build type",
         values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
     )
     variant(
         "precision",
         default="2",
+        sticky=True,
         description="Precision to use (1 or 2)",
         values=("1", "2"),
     )

--- a/spack_repo/access/nri/packages/access_mom6/package.py
+++ b/spack_repo/access/nri/packages/access_mom6/package.py
@@ -36,15 +36,17 @@ class AccessMom6(CMakePackage):
     version("2025.02.000", tag="2025.02.000", commit="e088c8b7f6c2b18b72edd568aa009e13396ec0c3")
 
     variant("openmp", default=False, sticky=True, description="Enable OpenMP")
-    variant("asymmetric_mem", default=False, description="Use asymmetric memory in MOM6")
+    variant("asymmetric_mem", default=False, sticky=True, description="Use asymmetric memory in MOM6")
     variant(
         "access3",
         default=True,
+        sticky=True,
         description="Install MOM6 as library for Access3 models"
     )
     variant(
         "mom6_solo",
         default=False,
+        sticky=True,
         description="Install MOM6 solo executable",
         when="@2025.07.001:"
     )

--- a/spack_repo/access/nri/packages/access_mom6/package.py
+++ b/spack_repo/access/nri/packages/access_mom6/package.py
@@ -35,7 +35,7 @@ class AccessMom6(CMakePackage):
     version("2025.02.001", tag="2025.02.001", commit="a5f4397b953f749acecf06f21129c2a20aa578fe")
     version("2025.02.000", tag="2025.02.000", commit="e088c8b7f6c2b18b72edd568aa009e13396ec0c3")
 
-    variant("openmp", default=False, description="Enable OpenMP")
+    variant("openmp", default=False, sticky=True, description="Enable OpenMP")
     variant("asymmetric_mem", default=False, description="Use asymmetric memory in MOM6")
     variant(
         "access3",

--- a/spack_repo/access/nri/packages/access_om2/package.py
+++ b/spack_repo/access/nri/packages/access_om2/package.py
@@ -19,7 +19,7 @@ class AccessOm2(BundlePackage):
 
     version("latest")
 
-    variant("deterministic", default=False, description="Deterministic build.")
+    variant("deterministic", default=False, sticky=True, description="Deterministic build.")
 
     depends_on("libaccessom2+deterministic", when="+deterministic", type="run")
     depends_on("libaccessom2~deterministic", when="~deterministic", type="run")

--- a/spack_repo/access/nri/packages/access_om2_bgc/package.py
+++ b/spack_repo/access/nri/packages/access_om2_bgc/package.py
@@ -19,7 +19,7 @@ class AccessOm2Bgc(BundlePackage):
 
     version("latest")
 
-    variant("deterministic", default=False, description="Deterministic build.")
+    variant("deterministic", default=False, sticky=True, description="Deterministic build.")
 
     depends_on("libaccessom2+deterministic", when="+deterministic", type="run")
     depends_on("libaccessom2~deterministic", when="~deterministic", type="run")

--- a/spack_repo/access/nri/packages/access_triangle/package.py
+++ b/spack_repo/access/nri/packages/access_triangle/package.py
@@ -23,7 +23,7 @@ class AccessTriangle(MakefilePackage):
     version("1.6.1", branch="main")
     
     # variant for building the showme utility (requires X11).
-    variant("showme", default=False,
+    variant("showme", default=False, sticky=True,
             description="Build the showme utility (requires libX11).")
 
     depends_on("c", type="build")

--- a/spack_repo/access/nri/packages/access_ww3/package.py
+++ b/spack_repo/access/nri/packages/access_ww3/package.py
@@ -21,7 +21,7 @@ class AccessWw3(CMakePackage):
     version("2025.08.000", tag="2025.08.000", commit="5ccdad475003c711ccb660039847759cc952519f")
     version("2025.03.0", tag="2025.03.0", commit="d980dececb8843da1769470f24bc633982073db6")
 
-    variant("openmp", default=False, description="Enable OpenMP")
+    variant("openmp", default=False, sticky=True, description="Enable OpenMP")
     variant(
         "access3",
         default=True,

--- a/spack_repo/access/nri/packages/access_ww3/package.py
+++ b/spack_repo/access/nri/packages/access_ww3/package.py
@@ -25,6 +25,7 @@ class AccessWw3(CMakePackage):
     variant(
         "access3",
         default=True,
+        sticky=True,
         description="Install WW3 as library for Access3 models"
     )
 

--- a/spack_repo/access/nri/packages/adjoint_petsc/package.py
+++ b/spack_repo/access/nri/packages/adjoint_petsc/package.py
@@ -37,9 +37,9 @@ class AdjointPetsc(CMakePackage):
 
     version("stable", branch="master", preferred=True)
 
-    variant("shared", default=True, description="Build shared libraries")
-    variant("examples", default=False, description="Build examples")
-    variant("build-tests", default=False, description="Enable CMake BUILD_TESTING targets")
+    variant("shared", default=True, sticky=True, description="Build shared libraries")
+    variant("examples", default=False, sticky=True, description="Build examples")
+    variant("build-tests", default=False, sticky=True, description="Enable CMake BUILD_TESTING targets")
 
     depends_on("cmake@3.20:", type="build")
     depends_on("pkgconfig", type="build")

--- a/spack_repo/access/nri/packages/ancoms_roms/package.py
+++ b/spack_repo/access/nri/packages/ancoms_roms/package.py
@@ -31,7 +31,7 @@ class AncomsRoms(MakefilePackage):
     version("3.6", tag="roms-3.6", commit="0db3bdc59587154c194deb246b0007f4f743b35a")
     version("3.5", tag="roms-3.5", commit="bf4c05eb1a4b384eda306c2ed74697284970e48a")
 
-    variant("openmp", default=False, description="Turn on shared-memory parallelization in ROMS")
+    variant("openmp", default=False, sticky=True, description="Turn on shared-memory parallelization in ROMS")
     variant("mpi", default=True, sticky=True, description="Turn on distributed-memory parallelization in ROMS")
     variant(
         "roms_application",

--- a/spack_repo/access/nri/packages/ancoms_roms/package.py
+++ b/spack_repo/access/nri/packages/ancoms_roms/package.py
@@ -36,6 +36,7 @@ class AncomsRoms(MakefilePackage):
     variant(
         "roms_application",
         default="benchmark",
+        sticky=True,
         description="Makefile to include its associated header file",
         values=("upwelling", "benchmark"),
         multi=False,
@@ -43,6 +44,7 @@ class AncomsRoms(MakefilePackage):
     variant(
         "debug",
         default=False,
+        sticky=True,
         description="Turn on symbolic debug information with no optimization",
     )
 

--- a/spack_repo/access/nri/packages/ancoms_roms/package.py
+++ b/spack_repo/access/nri/packages/ancoms_roms/package.py
@@ -32,7 +32,7 @@ class AncomsRoms(MakefilePackage):
     version("3.5", tag="roms-3.5", commit="bf4c05eb1a4b384eda306c2ed74697284970e48a")
 
     variant("openmp", default=False, description="Turn on shared-memory parallelization in ROMS")
-    variant("mpi", default=True, description="Turn on distributed-memory parallelization in ROMS")
+    variant("mpi", default=True, sticky=True, description="Turn on distributed-memory parallelization in ROMS")
     variant(
         "roms_application",
         default="benchmark",

--- a/spack_repo/access/nri/packages/cable/package.py
+++ b/spack_repo/access/nri/packages/cable/package.py
@@ -25,6 +25,7 @@ class Cable(CMakePackage):
     variant(
         "mpi",
         default=True,
+        sticky=True,
         description="Build MPI executable.",
     )
 

--- a/spack_repo/access/nri/packages/cable/package.py
+++ b/spack_repo/access/nri/packages/cable/package.py
@@ -16,7 +16,7 @@ class Cable(CMakePackage):
     git = "https://github.com/CABLE-LSM/CABLE.git"
 
     maintainers("SeanBryan51", "Whyborn")
-    
+
     license("LicenseRef-CSIRO-Open-Source-Software-License-v1.0", checked_by="anton-seaice")
 
     version("stable", branch="main", preferred=True)
@@ -33,6 +33,7 @@ class Cable(CMakePackage):
     variant(
         "library",
         default="none",
+        sticky=True,
         values=(
             "none",
             "access-esm1.6"
@@ -43,6 +44,7 @@ class Cable(CMakePackage):
     variant(
         "build_type",
         default="Release",
+        sticky=True,
         description="CMake build type",
         values=("Debug", "Release"),
     )

--- a/spack_repo/access/nri/packages/cice4/package.py
+++ b/spack_repo/access/nri/packages/cice4/package.py
@@ -26,6 +26,7 @@ class Cice4(MakefilePackage):
     variant(
         "direct_ldflags",
         default="none",
+        sticky=True,
         values="*",
         multi=False,
         description="Directly inject LDFLAGS into the Makefile",

--- a/spack_repo/access/nri/packages/cice5/package.py
+++ b/spack_repo/access/nri/packages/cice5/package.py
@@ -46,6 +46,7 @@ class Cice5(CMakePackage):
     variant(
         "model",
         default="access-om2",
+        sticky=True,
         values=("access-om2", "access-esm1.6"),
         description="Which model this build is coupled with"
     )
@@ -62,15 +63,15 @@ class Cice5(CMakePackage):
         msg="model=access-om2 not included in @access-esm1.6"
     )
 
-    variant("deterministic", default=False, description="Deterministic build.")
+    variant("deterministic", default=False, sticky=True, description="Deterministic build.")
 
-    variant("io_type", default="NetCDF", values=("NetCDF", "PIO"), description="CICE IO Method")
+    variant("io_type", default="NetCDF", sticky=True, values=("NetCDF", "PIO"), description="CICE IO Method")
     # User set integer cmake options:
-    variant("nxglob", default="none", values=_int_validator, description="Size of model grid in x")
-    variant("nyglob", default="none", values=_int_validator, description="Size of model grid in y")
-    variant("blckx", default="none", values=_int_validator, description="Size of computational blocks in x")
-    variant("blcky", default="none", values=_int_validator, description="Size of computational blocks in y")
-    variant("mxblcks", default="none", values=_int_validator, description="Max number of blocks per task")
+    variant("nxglob", default="none", sticky=True, values=_int_validator, description="Size of model grid in x")
+    variant("nyglob", default="none", sticky=True, values=_int_validator, description="Size of model grid in y")
+    variant("blckx", default="none", sticky=True, values=_int_validator, description="Size of computational blocks in x")
+    variant("blcky", default="none", sticky=True, values=_int_validator, description="Size of computational blocks in y")
+    variant("mxblcks", default="none", sticky=True, values=_int_validator, description="Max number of blocks per task")
 
     depends_on("c", type="build")
     depends_on("fortran", type="build")

--- a/spack_repo/access/nri/packages/fcm/package.py
+++ b/spack_repo/access/nri/packages/fcm/package.py
@@ -16,7 +16,7 @@ class Fcm(Package):
         sha256="b4178b488470aa391f29b46d19bd6395ace42ea06cb9678cabbd4604b46f56cd",
     )
 
-    variant("site", default="none", description="Site to use for keyword configuration",
+    variant("site", default="none", sticky=True, description="Site to use for keyword configuration",
         values=("none", "nci-gadi"), multi=False)
 
     depends_on("c", type="build")

--- a/spack_repo/access/nri/packages/fiat/package.py
+++ b/spack_repo/access/nri/packages/fiat/package.py
@@ -34,7 +34,7 @@ class Fiat(CMakePackage):
         values=("Debug", "Release", "RelWithDebInfo"),
     )
 
-    variant("mpi", default=True, description="Use MPI")
+    variant("mpi", default=True, sticky=True, description="Use MPI")
     variant("openmp", default=True, description="Use OpenMP")
     variant("fckit", default=True, description="Use fckit")
 

--- a/spack_repo/access/nri/packages/fiat/package.py
+++ b/spack_repo/access/nri/packages/fiat/package.py
@@ -35,7 +35,7 @@ class Fiat(CMakePackage):
     )
 
     variant("mpi", default=True, sticky=True, description="Use MPI")
-    variant("openmp", default=True, description="Use OpenMP")
+    variant("openmp", default=True, sticky=True, description="Use OpenMP")
     variant("fckit", default=True, description="Use fckit")
 
     depends_on("c", type="build")

--- a/spack_repo/access/nri/packages/fiat/package.py
+++ b/spack_repo/access/nri/packages/fiat/package.py
@@ -30,13 +30,14 @@ class Fiat(CMakePackage):
     variant(
         "build_type",
         default="RelWithDebInfo",
+        sticky=True,
         description="CMake build type",
         values=("Debug", "Release", "RelWithDebInfo"),
     )
 
     variant("mpi", default=True, sticky=True, description="Use MPI")
     variant("openmp", default=True, sticky=True, description="Use OpenMP")
-    variant("fckit", default=True, description="Use fckit")
+    variant("fckit", default=True, sticky=True, description="Use fckit")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")

--- a/spack_repo/access/nri/packages/fre_nctools/package.py
+++ b/spack_repo/access/nri/packages/fre_nctools/package.py
@@ -38,7 +38,7 @@ class FreNctools(AutotoolsPackage):
     version("2024.02", sha256="90d52abc1b467d635dd648185b0046efcc6d58a232143b0ccaf9a0bff23d2f5d")
     version("2022.02", sha256="bd90c9c3becdb19ff408c0915e61141376e81c12651a5c1b054c75ced9a73ad2")
 
-    variant("mpi", default=False, description="Builds with MPI support")
+    variant("mpi", default=False, sticky=True, description="Builds with MPI support")
 
     depends_on("c", type="build")
     depends_on("fortran", type="build")

--- a/spack_repo/access/nri/packages/gcom/package.py
+++ b/spack_repo/access/nri/packages/gcom/package.py
@@ -27,7 +27,7 @@ class Gcom(Package):
     version("8.3", tag="vn8.3", commit="b7b890a181d8e31e4e80b731b9f8ad9a6e1a8bed")
     version("8.4", tag="vn8.4", commit="f4fa92eb4af4f1e4cf9d608b441e3c96f77b6a6d")
 
-    variant("mpi", default=True, description="Build with MPI")
+    variant("mpi", default=True, sticky=True, description="Build with MPI")
 
     depends_on("c", type="build")
     depends_on("fortran", type="build")

--- a/spack_repo/access/nri/packages/gcom4/package.py
+++ b/spack_repo/access/nri/packages/gcom4/package.py
@@ -24,7 +24,7 @@ class Gcom4(Package):
 
     version("access-esm1.5", branch="access-esm1.5")
 
-    variant("mpi", default=True, description="Build with MPI")
+    variant("mpi", default=True, sticky=True, description="Build with MPI")
 
     depends_on("c", type="build")
     depends_on("fortran", type="build")

--- a/spack_repo/access/nri/packages/libaccessom2/package.py
+++ b/spack_repo/access/nri/packages/libaccessom2/package.py
@@ -18,10 +18,11 @@ class Libaccessom2(CMakePackage):
 
     version("access-om2", branch="master", preferred=True)
 
-    variant("deterministic", default=False, description="Deterministic build.")
-    variant("optimisation_report", default=False, description="Generate optimisation reports.")
+    variant("deterministic", default=False, sticky=True, description="Deterministic build.")
+    variant("optimisation_report", default=False, sticky=True, description="Generate optimisation reports.")
     variant('build_type',
             default='Release',
+            sticky=True,
             description='The build type to build',
             values=('Debug', 'Release')
     )

--- a/spack_repo/access/nri/packages/mom5/package.py
+++ b/spack_repo/access/nri/packages/mom5/package.py
@@ -42,22 +42,25 @@ class Mom5(CMakePackage, MakefilePackage):
     with when("build_system=cmake"):
         depends_on("cmake@3.18:", type="build")
         variant("build_type", default="RelWithDebInfo",
+            sticky=True,
             description="CMake build type",
             values=("Debug", "Release", "RelWithDebInfo")
         )
-        variant("deterministic", default=False, description="Deterministic build")
+        variant("deterministic", default=False, sticky=True, description="Deterministic build")
 
     with when("build_system=makefile"):
-        variant("restart_repro", default=True, description="Reproducible restart build.")
+        variant("restart_repro", default=True, sticky=True, description="Reproducible restart build.")
         variant(
             "deterministic",
             default=False,
+            sticky=True,
             description="Deterministic build",
             when="@access-om2,legacy-access-om2-bgc"
         )
         variant(
             "optimisation_report",
             default=False,
+            sticky=True,
             description="Generate optimisation reports",
             when="@access-om2,legacy-access-om2-bgc"
         )

--- a/spack_repo/access/nri/packages/oasis3_mct/package.py
+++ b/spack_repo/access/nri/packages/oasis3_mct/package.py
@@ -29,8 +29,8 @@ class Oasis3Mct(MakefilePackage):
     version("access-om2", branch="master")
     version("access-esm1.5", branch="access-esm1.5")
 
-    variant("deterministic", default=False, description="Deterministic build.")
-    variant("optimisation_report", default=False, description="Generate optimisation reports.")
+    variant("deterministic", default=False, sticky=True, description="Deterministic build.")
+    variant("optimisation_report", default=False, sticky=True, description="Generate optimisation reports.")
 
     depends_on("c", type="build")
     depends_on("fortran", type="build")

--- a/spack_repo/access/nri/packages/um/package.py
+++ b/spack_repo/access/nri/packages/um/package.py
@@ -40,7 +40,7 @@ class Um(UmBasePackage):
 
     # Include openmpi directly.
     # https://github.com/ACCESS-NRI/access-spack-packages/issues/293
-    variant("mpi", default=True, description="Build with MPI")
+    variant("mpi", default=True, sticky=True, description="Build with MPI")
     depends_on("mpi", when="+mpi", type=("build", "link", "run"))
 
     variant("access3", default=False,

--- a/spack_repo/access/nri/packages/um/package.py
+++ b/spack_repo/access/nri/packages/um/package.py
@@ -16,7 +16,8 @@ class Um(UmBasePackage):
     """
 
     # Gets URL from the base package
-    variant("model", default="vn13", description="Model configuration.",
+    variant("model", default="vn13", sticky=True,
+        description="Model configuration.",
         values=("vn13", "vn13p0-rns", "vn13p1-am", "vn13p5-rns"), multi=False)
 
     # List of model variants that have been migrated to Github sources.
@@ -43,7 +44,7 @@ class Um(UmBasePackage):
     variant("mpi", default=True, sticky=True, description="Build with MPI")
     depends_on("mpi", when="+mpi", type=("build", "link", "run"))
 
-    variant("access3", default=False,
+    variant("access3", default=False, sticky=True,
         description="Install UM as library for Access3 models")
 
     with when("+access3"):

--- a/spack_repo/access/nri/packages/um7/package.py
+++ b/spack_repo/access/nri/packages/um7/package.py
@@ -41,9 +41,11 @@ class Um7(Package):
     variant(
         "full",
         default=True,
+        sticky=True,
         description="Full (fresh) build. Disable for incremental build"
     )
-    variant("optim", default="high", description="Optimization level",
+    variant("optim", default="high", sticky=True,
+            description="Optimization level",
             values=("high", "debug"), multi=False)
 
     with when("@access-esm1.6"):

--- a/spack_repo/access/nri/packages/um_createbc/package.py
+++ b/spack_repo/access/nri/packages/um_createbc/package.py
@@ -12,7 +12,8 @@ class UmCreatebc(UmBasePackage):
     UmCreatebc creates local boundary conditions for the UM weather and climate model.
     """
 
-    variant("model", default="vn13", description="Model configuration.",
+    variant("model", default="vn13", sticky=True,
+        description="Model configuration.",
         values=("vn13", "vn13p5-rns"), multi=False)
 
     # List of model variants that have been migrated to Github sources.


### PR DESCRIPTION
Force Spack to choose the default option of a variant when there is no explicit variant option set in the spec. https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#sticky-variants

