### PR TITLE
`generate-manifest-matrix` action: Use custom path to avoid dubious git ownership

### DIFF
--- a/.github/build-ci/actions/generate-manifest-matrix/action.yaml
+++ b/.github/build-ci/actions/generate-manifest-matrix/action.yaml
@@ -45,10 +45,12 @@ runs:
       with:
         repository: ACCESS-NRI/access-spack-packages
         ref: ${{ inputs.ref }}
+        path: fallback
 
     - name: Get default inputs.ref for fallback repository
       id: default
       shell: bash
+      working-directory: fallback
       run: |
         if [[ -z "${{ inputs.ref }}" ]]; then
           ref=$(git branch --show-current)


### PR DESCRIPTION
See failed run https://github.com/ACCESS-NRI/upstream-spack-packages/actions/runs/28629889291/job/84904305823

## Background

Due to how the interactions between containers and runners works, repositories cloned under `$GITHUB_WORKSPACE` may have dubious ownership to `git`, as above. To fix this, we use a custom path that does not have dubious ownership.

## The PR

* Clone `access-spack-packages` under a `fallback` directory, and use this directory as the working directory when determining the default `access-spack-packages` ref. 

## Testing

See successful setup of CI in https://github.com/ACCESS-NRI/upstream-spack-packages/actions/runs/28630048984/job/84904790685?pr=5
