### PR TITLE
gcom4: version 4.5 does not support gcc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,6 @@ jobs:
           - package: {template_value: "access-issm"}
           - package: {template_value: "access-test"}
           - package: {template_value: "coastri-roms"}
-          - package: {template_value: "gcom4"}
     uses: access-nri/build-ci/.github/workflows/ci.yml@v3
     with:
       spack-manifest-repository: ${{ matrix.package.repository }}

--- a/spack_repo/access/nri/packages/gcom4/package.py
+++ b/spack_repo/access/nri/packages/gcom4/package.py
@@ -41,8 +41,11 @@ class Gcom4(Package):
             mach_c = "ifort"
         elif spec.satisfies("%oneapi"):
             mach_c = "oneapi"
-        elif spec.satisfies("%gcc"):
-            mach_c = "gfortran"
+        # https://github.com/ACCESS-NRI/access-spack-packages/issues/85
+        # versions 4.7 and 4.8 support the gcc Fortran compiler,
+        # but versions 4.5 and 4.6 do not.
+        # elif spec.satisfies("%gcc"):
+        #     mach_c = "gfortran"
         else:
             raise NotImplementedError("Unknown compiler")
         if "+mpi" in spec:


### PR DESCRIPTION
Closes: https://github.com/ACCESS-NRI/access-spack-packages/issues/85

Versions 4.7 and 4.8 support the gcc Fortran compiler, but versions 4.5 and 4.6 do not.