### PR TITLE
Make Exclusion Matrix A Common File

### DIFF
--- a/.github/build-ci/actions/generate-manifest-matrix/README.md
+++ b/.github/build-ci/actions/generate-manifest-matrix/README.md
@@ -113,7 +113,6 @@ Note that the `package` section comes from the matrix name, and `template_value`
   {"package": {"template_value": "access-issm"}},
   {"package": {"template_value": "access-test"}},
   {"package": {"template_value": "coastri-roms"}},
-  {"package": {"template_value": "gcom4"}}
 ]
 ```
 

--- a/.github/build-ci/actions/generate-manifest-matrix/README.md
+++ b/.github/build-ci/actions/generate-manifest-matrix/README.md
@@ -99,20 +99,20 @@ jobs:
 
 ### Exclude Matrix
 
-Note that the `package` section comes from the matrix name, and `template_value` from the matrix itself - the package name!
+In this example, the packages below are excluded because they are all Spack Bundle Recipes (SBRs), which are tested and deployed separately in Model Deployment Repositories (MDRs).
 
 ```json
 [
-  {"package": {"template_value": "access-om2"}},
-  {"package": {"template_value": "access-om2-bgc"}},
-  {"package": {"template_value": "access-om3"}},
-  {"package": {"template_value": "access-esm1p5"}},
-  {"package": {"template_value": "access-esm1p6"}},
-  {"package": {"template_value": "access-am3"}},
-  {"package": {"template_value": "access-ram3"}},
-  {"package": {"template_value": "access-issm"}},
-  {"package": {"template_value": "access-test"}},
-  {"package": {"template_value": "coastri-roms"}},
+  "access-om2",
+  "access-om2-bgc",
+  "access-om3",
+  "access-esm1p5",
+  "access-esm1p6",
+  "access-am3",
+  "access-ram3",
+  "access-issm",
+  "access-test",
+  "coastri-roms"
 ]
 ```
 

--- a/.github/build-ci/actions/generate-manifest-matrix/README.md
+++ b/.github/build-ci/actions/generate-manifest-matrix/README.md
@@ -34,6 +34,7 @@ Each matrix entry contains:
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | `matrix` | JSON array | A GitHub Actions matrix of `{template_value, repository, ref, filepath}` tuples |
+| `exclude-matrix` | JSON array | A GitHub Actions matrix of packages to exlude from matrix generation |
 
 ## Example
 
@@ -58,7 +59,8 @@ jobs:
     needs: setup
     strategy:
       matrix:
-        config: ${{ fromJson(needs.setup.outputs.matrix) }}
+        packages: ${{ fromJson(needs.setup.outputs.matrix) }}
+        exclude: ${{ fromJson(needs.setup.outputs.exclude-matrix) }}
     uses: access-nri/build-ci/.github/workflows/ci.yml@v3
     with:
       spack-manifest-repository: ${{ matrix.config.repository }}
@@ -69,6 +71,8 @@ jobs:
 ```
 
 ## Example Output
+
+### Matrix
 
 ```json
 [
@@ -90,6 +94,26 @@ jobs:
     "ref": "main",
     "filepath": ".github/build-ci/manifests/cice5/gcc.spack.yaml.j2"
   }
+]
+```
+
+### Exclude Matrix
+
+Note that the `package` section comes from the matrix name, and `template_value` from the matrix itself - the package name!
+
+```json
+[
+  {"package": {"template_value": "access-om2"}},
+  {"package": {"template_value": "access-om2-bgc"}},
+  {"package": {"template_value": "access-om3"}},
+  {"package": {"template_value": "access-esm1p5"}},
+  {"package": {"template_value": "access-esm1p6"}},
+  {"package": {"template_value": "access-am3"}},
+  {"package": {"template_value": "access-ram3"}},
+  {"package": {"template_value": "access-issm"}},
+  {"package": {"template_value": "access-test"}},
+  {"package": {"template_value": "coastri-roms"}},
+  {"package": {"template_value": "gcom4"}}
 ]
 ```
 

--- a/.github/build-ci/actions/generate-manifest-matrix/action.yaml
+++ b/.github/build-ci/actions/generate-manifest-matrix/action.yaml
@@ -21,6 +21,10 @@ outputs:
     description: |
       A GitHub Actions matrix of repository, ref, manifest path, and package name tuples.
     value: ${{ steps.gen.outputs.matrix }}
+  exclude-matrix:
+    description: |
+      A GitHub Actions matrix of excluded matrix entries
+    value: ${{ steps.exclude.outputs.matrix }}
 runs:
   using: composite
   steps:
@@ -160,3 +164,16 @@ runs:
 
         # Remove the trailing comma and wrap in square brackets
         echo "matrix=[${json_entries%,}]" >> $GITHUB_OUTPUT
+
+    - name: Generate exclude matrix
+      shell: bash
+      id: exclude
+      env:
+        EXCLUSION_MATRIX_FILE_PATH: .github/build-ci/data/exclude.json
+      run: |
+        matrix="$(jq -cr . ${{ env.EXCLUSION_MATRIX_FILE_PATH }})"
+
+        echo "Exclusion matrix from ${{ env.EXCLUSION_MATRIX_FILE_PATH }}:"
+        echo "$matrix"
+
+        echo "matrix=$matrix" >> $GITHUB_OUTPUT

--- a/.github/build-ci/actions/generate-manifest-matrix/action.yaml
+++ b/.github/build-ci/actions/generate-manifest-matrix/action.yaml
@@ -171,7 +171,7 @@ runs:
       env:
         EXCLUSION_MATRIX_FILE_PATH: .github/build-ci/data/exclude.json
       run: |
-        matrix="$(jq -cr . ${{ env.EXCLUSION_MATRIX_FILE_PATH }})"
+        matrix="$(jq -cr '[.[] | {package: {template_value: .}}]' ${{ env.EXCLUSION_MATRIX_FILE_PATH }})"
 
         echo "Exclusion matrix from ${{ env.EXCLUSION_MATRIX_FILE_PATH }}:"
         echo "$matrix"

--- a/.github/build-ci/data/exclude.json
+++ b/.github/build-ci/data/exclude.json
@@ -1,12 +1,12 @@
 [
-	{"package": {"template_value": "access-om2"}},
-	{"package": {"template_value": "access-om2-bgc"}},
-	{"package": {"template_value": "access-om3"}},
-	{"package": {"template_value": "access-esm1p5"}},
-	{"package": {"template_value": "access-esm1p6"}},
-	{"package": {"template_value": "access-am3"}},
-	{"package": {"template_value": "access-ram3"}},
-	{"package": {"template_value": "access-issm"}},
-	{"package": {"template_value": "access-test"}},
-	{"package": {"template_value": "coastri-roms"}}
+	"access-om2",
+	"access-om2-bgc",
+	"access-om3",
+	"access-esm1p5",
+	"access-esm1p6",
+	"access-am3",
+	"access-ram3",
+	"access-issm",
+	"access-test",
+	"coastri-roms"
 ]

--- a/.github/build-ci/data/exclude.json
+++ b/.github/build-ci/data/exclude.json
@@ -1,0 +1,13 @@
+[
+	{"package": {"template_value": "access-om2"}},
+	{"package": {"template_value": "access-om2-bgc"}},
+	{"package": {"template_value": "access-om3"}},
+	{"package": {"template_value": "access-esm1p5"}},
+	{"package": {"template_value": "access-esm1p6"}},
+	{"package": {"template_value": "access-am3"}},
+	{"package": {"template_value": "access-ram3"}},
+	{"package": {"template_value": "access-issm"}},
+	{"package": {"template_value": "access-test"}},
+	{"package": {"template_value": "coastri-roms"}},
+	{"package": {"template_value": "gcom4"}}
+]

--- a/.github/build-ci/data/exclude.json
+++ b/.github/build-ci/data/exclude.json
@@ -8,6 +8,5 @@
 	{"package": {"template_value": "access-ram3"}},
 	{"package": {"template_value": "access-issm"}},
 	{"package": {"template_value": "access-test"}},
-	{"package": {"template_value": "coastri-roms"}},
-	{"package": {"template_value": "gcom4"}}
+	{"package": {"template_value": "coastri-roms"}}
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,9 @@ jobs:
       BUILD_CI_WORKFLOW_VERSION: v3
       PACKAGES_ROOT_DIR: spack_repo/access/nri/packages
     outputs:
+      # Output both a matrix of {repo, ref, path, package}s, and a matrix of packages for exclusion
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      exclude-matrix: ${{ steps.set-matrix.outputs.exclude-matrix }}
       builtin-spack-packages-ref: ${{ inputs.builtin-spack-packages-ref }}
       access-spack-packages-ref: ${{ inputs.access-spack-packages-ref || github.event.pull_request.head.sha }}
       spack-config-ref: ${{ inputs.spack-config-ref || steps.defaults.outputs.spack-config-ref }}
@@ -142,17 +144,7 @@ jobs:
       max-parallel: 10
       matrix:
         package: ${{ fromJson(needs.setup-ci.outputs.matrix) }}
-        exclude:
-          - package: {template_value: "access-om2"}
-          - package: {template_value: "access-om2-bgc"}
-          - package: {template_value: "access-om3"}
-          - package: {template_value: "access-esm1p5"}
-          - package: {template_value: "access-esm1p6"}
-          - package: {template_value: "access-am3"}
-          - package: {template_value: "access-ram3"}
-          - package: {template_value: "access-issm"}
-          - package: {template_value: "access-test"}
-          - package: {template_value: "coastri-roms"}
+        exclude: ${{ fromJson(needs.setup-ci.outputs.exclude-matrix) }}
     uses: access-nri/build-ci/.github/workflows/ci.yml@v3
     with:
       spack-manifest-repository: ${{ matrix.package.repository }}


### PR DESCRIPTION
See https://github.com/ACCESS-NRI/upstream-spack-packages/pull/5#discussion_r3527039108

## Background

We now have the same exclusion list across `*-access-spack-packages` and `spack-config`. A change to one would mean a change to all.

In this PR, we change it from an inline matrix to a file that is read as part of the `generate-manifest-matrix` action (which repos like the above use). 

## The PR

* Add `.github/build-ci/data/exclude.json`, replacing the matrix in `ci.yml`
* Read in the above in the `generate-manifest-matrix` action step

## Testing

Tested in https://github.com/ACCESS-NRI/access-spack-packages/actions/runs/28834166060?pr=457 in https://github.com/ACCESS-NRI/access-spack-packages/pull/457/commits/6be24320b22d1db28784ab384f4e87e4db30f9b7, note the lack of `access_om2`, as expected
