### PR TITLE
gcom4: add conflicts("%gcc") to force concretization error

### DIFF
--- a/spack_repo/access/nri/packages/gcom4/package.py
+++ b/spack_repo/access/nri/packages/gcom4/package.py
@@ -32,6 +32,7 @@ class Gcom4(Package):
     depends_on("fcm", type="build")
     depends_on("mpi", when="+mpi")
 
+    conflicts("%gcc")
 
     def gcom_machine(self, spec):
         """


### PR DESCRIPTION
Closes: https://github.com/ACCESS-NRI/access-spack-packages/issues/85