### PR TITLE
gcom4: add new version "stable" mapping to branch access-esm1.6

### DIFF
--- a/spack_repo/access/nri/packages/gcom4/package.py
+++ b/spack_repo/access/nri/packages/gcom4/package.py
@@ -22,6 +22,7 @@ class Gcom4(Package):
 
     maintainers("penguian")
 
+    version("stable", branch="access-esm1.6", preferred=True)
     version("access-esm1.5", branch="access-esm1.5")
 
     variant("mpi", default=True, sticky=True, description="Build with MPI")


### PR DESCRIPTION
GCOM4 needs to move to using ACCESS-NRI's versioning scheme. For example:
https://github.com/ACCESS-NRI/access-spack-packages/blob/f77f11a07d698a8b7c062ef2904f4d52d9d3eab1/spack_repo/access/nri/packages/access_generic_tracers/package.py#L24-L36