### PR TITLE
Changes to UM build system and CABLE package to build AM3 with CABLE library

### DIFF
--- a/spack_repo/access/nri/build_systems/um_base.py
+++ b/spack_repo/access/nri/build_systems/um_base.py
@@ -58,7 +58,8 @@ class UmBasePackage(Package):
     _bool_variants = (
         "DR_HOOK",
         "eccodes",
-        "netcdf")
+        "netcdf",
+        "cable")
     for var in _bool_variants:
         variant(var, default=True, sticky=True, description=var)
 
@@ -180,6 +181,7 @@ class UmBasePackage(Package):
         when="+eccodes")
     depends_on("netcdf-fortran@4.5.2:", type=("build", "link", "run"),
         when="+netcdf")
+    depends_on("cable library='access3'", type=("build", "link", "run"))
 
     phases = ["build", "install"]
 
@@ -203,7 +205,12 @@ class UmBasePackage(Package):
             "includes": ["include"],
             "dep_name": "netcdf-fortran",
             "fcm_name": "netcdf",
-            "fcm_ld_flags": "-lnetcdff -lnetcdf"}}
+            "fcm_ld_flags": "-lnetcdff -lnetcdf"},
+        "cable": {
+            "includes": ["include"],
+            "dep_name": "cable",
+            "fcm_name": "cable",
+            "fcm_ld_flags": ""}}
 
     # List of model variants that have Github sources.
     # Should be overridden by child classes.

--- a/spack_repo/access/nri/packages/cable/package.py
+++ b/spack_repo/access/nri/packages/cable/package.py
@@ -36,7 +36,8 @@ class Cable(CMakePackage):
         sticky=True,
         values=(
             "none",
-            "access-esm1.6"
+            "access-esm1.6",
+            "access3"
         ),
         description="Build CABLE science library object.",
     )

--- a/spack_repo/access/nri/packages/um/model/vn13p1-am/rose-app.conf
+++ b/spack_repo/access/nri/packages/um/model/vn13p1-am/rose-app.conf
@@ -53,3 +53,4 @@ ukca_sources=branches/dev/martindix/um13.1_cable_deposition@3051
             =branches/dev/martinwillett/um13.1_BlackCarbonRho1900@981
 um_rev=vn13.1
 um_sources=
+cable=true


### PR DESCRIPTION
Brings CABLE as a library for AM3. Treats CABLE like other external libraries in the `um_base` build system, and adds the `access3` value for the CABLE `library` variant.