### PR TITLE
Delete redundant url_for_version() definitions

### DIFF
--- a/spack_repo/access/nri/packages/access_fms/package.py
+++ b/spack_repo/access/nri/packages/access_fms/package.py
@@ -48,9 +48,6 @@ class AccessFms(CMakePackage):
     depends_on("netcdf-fortran")
     depends_on("mpi")
 
-    def url_for_version(self, version):
-        return "https://github.com/ACCESS-NRI/FMS/tarball/{0}".format(version)
-
     @property
     def headers(self):
         return find_headers(

--- a/spack_repo/access/nri/packages/access_test_component/package.py
+++ b/spack_repo/access/nri/packages/access_test_component/package.py
@@ -28,6 +28,3 @@ class AccessTestComponent(CMakePackage):
     depends_on("mpi", type=("build", "link", "run"))
 
     root_cmakelists_dir = "stub"
-
-    def url_for_version(self, version):
-        return f"https://github.com/{self.githubrepo}/tarball/{version}"

--- a/spack_repo/access/nri/packages/access_triangle/package.py
+++ b/spack_repo/access/nri/packages/access_triangle/package.py
@@ -31,9 +31,6 @@ class AccessTriangle(MakefilePackage):
     # Make libX11 conditional on +showme
     depends_on("libx11", when="+showme", type="link")
     
-    def url_for_version(self, version):
-        return "https://github.com/ACCESS-NRI/issm-triangle/archive/refs/heads/{0}.tar.gz".format(version)
-
     def edit(self, spec, prefix):
         """
         Below, we just copy in the 'configs'

--- a/spack_repo/access/nri/packages/issm/package.py
+++ b/spack_repo/access/nri/packages/issm/package.py
@@ -143,15 +143,6 @@ class Issm(AutotoolsPackage):
     requires("+wrappers", when="+py-tools", msg="The +py-tools variant requires +wrappers for full functionality")
 
     # --------------------------------------------------------------------
-    # Helper functions
-    # --------------------------------------------------------------------
-    def url_for_version(self, version):
-        """Tarball URL for Spack-generated versions."""
-        if version == Version("upstream"):
-            return "https://github.com/ISSMteam/ISSM/archive/refs/heads/main.tar.gz"
-        return f"https://github.com/ACCESS-NRI/ISSM/archive/refs/heads/{version}.tar.gz"
-
-    # --------------------------------------------------------------------
     # Build environment - inject AD and/or OpenMP compiler flags when needed
     # --------------------------------------------------------------------
     def setup_build_environment(self, env):

--- a/spack_repo/access/nri/packages/libaccessom2/package.py
+++ b/spack_repo/access/nri/packages/libaccessom2/package.py
@@ -39,9 +39,6 @@ class Libaccessom2(CMakePackage):
     depends_on("json-fortran")
     depends_on("netcdf-fortran@4.5.2:")
 
-    def url_for_version(self, version):
-        return "https://github.com/ACCESS-NRI/libaccessom2/tarball/{0}".format(version)
-
     # https://spack.readthedocs.io/en/latest/packaging_guide.html
     def patch(self):
         if "+deterministic" in self.spec:

--- a/spack_repo/access/nri/packages/mom5/package.py
+++ b/spack_repo/access/nri/packages/mom5/package.py
@@ -98,9 +98,6 @@ class Mom5(CMakePackage, MakefilePackage):
         depends_on("openmpi")
         depends_on("oasis3-mct@access-esm1.5")
 
-    def url_for_version(self, version):
-        return "https://github.com/ACCESS-NRI/mom5/tarball/{0}".format(version)
-
 
 class CMakeBuilder(cmake.CMakeBuilder):
     root_cmakelists_dir = "cmake/"

--- a/spack_repo/access/nri/packages/oasis3_mct/package.py
+++ b/spack_repo/access/nri/packages/oasis3_mct/package.py
@@ -62,13 +62,6 @@ class Oasis3Mct(MakefilePackage):
     # use both the psmile and mct libraries $ARCHDIR/lib/libpsmile.MPI1.a
     # and libmct.a and libmpeu.a when linking.
 
-    # TODO: Remove this function when it is no longer required
-    def url_for_version(self, version):
-        if self.spec.satisfies("@upstream"):
-            raise ValueError("url_for_version() called for version @upstream")
-
-        return "https://github.com/ACCESS-NRI/oasis3-mct/tarball/{0}".format(version)
-
     def __create_pkgconfig(self, spec, prefix):
 
         oasis_version = "2.0"


### PR DESCRIPTION
* Suggested by Claude Opus 4.8.

Claude:
I re-ran the verification on the new tip:

* ruff 0.1.1 check --preview --config .ruff.toml on the 7 changed files — clean.
* Fetch-strategy test — all 32 versions across the 10 packages resolve identically to the api-v2 baseline; the 22 git versions still never call url_for_version, and datetime_fortran / fcm / fortranxml still hold theirs.