### PR TITLE
Cable is dep only when +cable

### DIFF
--- a/spack_repo/access/nri/build_systems/um_base.py
+++ b/spack_repo/access/nri/build_systems/um_base.py
@@ -181,7 +181,8 @@ class UmBasePackage(Package):
         when="+eccodes")
     depends_on("netcdf-fortran@4.5.2:", type=("build", "link", "run"),
         when="+netcdf")
-    depends_on("cable library='access3'", type=("build", "link", "run"))
+    depends_on("cable library='access3'", type=("build", "link", "run"),
+        when="+cable")
 
     phases = ["build", "install"]
 

--- a/spack_repo/access/nri/build_systems/um_base.py
+++ b/spack_repo/access/nri/build_systems/um_base.py
@@ -58,11 +58,15 @@ class UmBasePackage(Package):
     _bool_variants = (
         "DR_HOOK",
         "eccodes",
-        "netcdf",
-        "cable")
+        "netcdf"
+    )
     for var in _bool_variants:
         variant(var, default=True, sticky=True, description=var)
 
+    # We don't want cable to be on by default, but otherwise we want it treated like a bool variant
+    variant("cable", default=False, sticky=True, description="Whether to use CABLE library")
+    _bool_variants = _bool_variants + ("cable",)
+    
     # Off/on variants have 3-value "none" "off", "on" logic.
     _off_on_variants = (
         "openmp",

--- a/spack_repo/access/nri/packages/um/model/vn13/rose-app.conf
+++ b/spack_repo/access/nri/packages/um/model/vn13/rose-app.conf
@@ -48,3 +48,4 @@ ukca_rev=
 ukca_sources=
 um_rev=
 um_sources=
+cable=false


### PR DESCRIPTION
Applies Anton's suggestion, to only include CABLE as a dependency when the spec has `+cable`.