### PR TITLE
Add WW3 2026.03.001

### DIFF
--- a/spack_repo/access/nri/packages/access_ww3/package.py
+++ b/spack_repo/access/nri/packages/access_ww3/package.py
@@ -17,7 +17,6 @@ class AccessWw3(CMakePackage):
     license("LGPL-3.0-only", checked_by="anton-seaice")
 
     version("stable", branch="dev/2026.03", preferred=True)   # need to update branch for new major versions
-    version("2026.08.000", tag="2026.08.000", commit="0a23b2c358150b420919f47545ae81b76fa39a0f")
     version("2026.03.001", tag="2026.03.001", commit="0a23b2c358150b420919f47545ae81b76fa39a0f")
     version("2026.03.000", tag="2026.03.000", commit="1845b8c17321e8625829f8edad763f44722cfeac")
     version("2025.08.000", tag="2025.08.000", commit="5ccdad475003c711ccb660039847759cc952519f")

--- a/spack_repo/access/nri/packages/access_ww3/package.py
+++ b/spack_repo/access/nri/packages/access_ww3/package.py
@@ -17,6 +17,7 @@ class AccessWw3(CMakePackage):
     license("LGPL-3.0-only", checked_by="anton-seaice")
 
     version("stable", branch="dev/2026.03", preferred=True)   # need to update branch for new major versions
+    version("2026.08.000", tag="2026.08.000", commit="0a23b2c358150b420919f47545ae81b76fa39a0f")
     version("2026.03.000", tag="2026.03.000", commit="1845b8c17321e8625829f8edad763f44722cfeac")
     version("2025.08.000", tag="2025.08.000", commit="5ccdad475003c711ccb660039847759cc952519f")
     version("2025.03.0", tag="2025.03.0", commit="d980dececb8843da1769470f24bc633982073db6")

--- a/spack_repo/access/nri/packages/access_ww3/package.py
+++ b/spack_repo/access/nri/packages/access_ww3/package.py
@@ -18,6 +18,7 @@ class AccessWw3(CMakePackage):
 
     version("stable", branch="dev/2026.03", preferred=True)   # need to update branch for new major versions
     version("2026.08.000", tag="2026.08.000", commit="0a23b2c358150b420919f47545ae81b76fa39a0f")
+    version("2026.03.001", tag="2026.03.001", commit="0a23b2c358150b420919f47545ae81b76fa39a0f")
     version("2026.03.000", tag="2026.03.000", commit="1845b8c17321e8625829f8edad763f44722cfeac")
     version("2025.08.000", tag="2025.08.000", commit="5ccdad475003c711ccb660039847759cc952519f")
     version("2025.03.0", tag="2025.03.0", commit="d980dececb8843da1769470f24bc633982073db6")


### PR DESCRIPTION
Add the ACCESS-NRI WW3 [2026.08.000](https://github.com/ACCESS-NRI/WW3/releases/tag/2026.08.000) release version, pinned to commit [0a23b2c358150b420919f47545ae81b76fa39a0f](https://github.com/ACCESS-NRI/WW3/commit/0a23b2c358150b420919f47545ae81b76fa39a0f). The moving stable branch remains unchanged.