### PR TITLE
Modify vn13.8-am rose config to include cable

### DIFF
--- a/spack_repo/access/nri/packages/um/model/vn13p8-am/rose-app.conf
+++ b/spack_repo/access/nri/packages/um/model/vn13p8-am/rose-app.conf
@@ -8,6 +8,7 @@ keys_recon_extra=
 
 COUPLER=none
 DR_HOOK=false
+cable=true
 casim_rev=um13.8
 casim_sources=
 compile_atmos=preprocess-atmos build-atmos


### PR DESCRIPTION
Enable cable option in rose-app.conf. The vn13.8 and cable library work were going on in parallel, so this didn't catch this change that is now necessary.