### PR TITLE
Remove unnecessary preproc directives

### DIFF
--- a/spack_repo/access/nri/packages/um/model/vn13p8-am/rose-app.conf
+++ b/spack_repo/access/nri/packages/um/model/vn13p8-am/rose-app.conf
@@ -2,8 +2,8 @@
 #meta=um-fcm-make/vn13.8
 
 [env]
-keys_atmos_extra=CABLE_UM_ISSUE24 CABLE_UM_ISSUE18 
-keys_scm_extra=CABLE_UM_ISSUE24 CABLE_UM_ISSUE18 
+keys_atmos_extra=CABLE_UM_ISSUE18 
+keys_scm_extra=CABLE_UM_ISSUE18 
 keys_recon_extra=
 
 COUPLER=none


### PR DESCRIPTION
The `CABLE_UM_ISSUE24` preproc directive was removed when we merged with UM v13.8.