### PR TITLE
access-fms: Add 2025.08.001

### DIFF
--- a/spack_repo/access/nri/packages/access_fms/package.py
+++ b/spack_repo/access/nri/packages/access_fms/package.py
@@ -25,6 +25,11 @@ class AccessFms(CMakePackage):
 
     version("stable", branch="mom5", preferred=True)
     version(
+        "2025.08.001",
+        tag="mom5-2025.08.001",
+        commit="3636de1e2501aa3441f52e240492e514b7e7c179"
+    )
+    version(
         "2025.08.000",
         tag="mom5-2025.08.000",
         commit="bf5f05bbf817b0168773fb2737e9d707c989fb43"


### PR DESCRIPTION
This PR adds the new 2025.08.001 version to the access-fms SPR