### PR TITLE
Add um7 version 2026.04.002

### DIFF
--- a/spack_repo/access/nri/packages/um7/package.py
+++ b/spack_repo/access/nri/packages/um7/package.py
@@ -25,10 +25,15 @@ class Um7(Package):
     # https://code.metoffice.gov.uk/trac/um/wiki/PastReleases
     version("stable", branch="dev-access-esm1.6", preferred=True)
     version(
+        "2026.04.002",
+        tag="2026.04.002",
+        commit="1fe253a3520c978ca8e2af700915bbda98cdf166"
+    )
+    version(
         "2026.04.001",
         tag="2026.04.001",
         commit="22cde94f5b58690b2db4af0bbb4524b9a8130094"
-        )
+    )
     version(
         "2026.04.000",
         tag="2026.04.000",


### PR DESCRIPTION
This PR adds the latest um7 version, 2026.04.002, to the um7 spack package. @harshula fyi – this will be the first um7 version which supports gfortran.

